### PR TITLE
Resolves #35 - Fix bug in router

### DIFF
--- a/src/containers/Router.jsx
+++ b/src/containers/Router.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 import App from '../components/App';
 import Signin from '../containers/SignIn';
@@ -11,8 +11,10 @@ import Signin from '../containers/SignIn';
  */
 const Router = () => (
   <BrowserRouter>
-    <Route path='/' exact component={Signin} />
-    <Route path='/my-activities' exact component={App} />
+    <Switch>
+      <Route path='/' exact component={Signin} />
+      <Route path='/my-activities' exact component={App} />
+    </Switch>
   </BrowserRouter>
 );
 

--- a/tests/containers/Router.test.jsx
+++ b/tests/containers/Router.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Router from '../../src/containers/Router';
+
+describe('<Router />', () => {
+  it('should render without crashing', () => {
+    expect(mount.bind(null, <Router />)).not.toThrow();
+  });
+});


### PR DESCRIPTION
**Description**
The `BrowserRouter` Component does not accept more than one child. This causes the app to throw an error.

**Fix**
Add Switch as the only child of  `BrowserRouter` component.

**How to test**
While in root folder of the project, run:
- `git pull`
- `git checkout fix-35-fix-bug-in-router`
- `yarn start`

Make sure the sign in page shows and there are no errors in the console related to `BrowesrRouter`.