### PR TITLE
[#156034201] Display notification on the Sign in page when user is redirected from protected route

### DIFF
--- a/src/containers/Page.jsx
+++ b/src/containers/Page.jsx
@@ -50,7 +50,7 @@ class Page extends Component {
     const tokenInfo = decodeToken(token);
     if (token === null || tokenIsValid(tokenInfo) === false || isFellow(tokenInfo) === false) {
       setSignInError();
-      this.props.history.push('/');
+      this.props.history.push({ pathname: '/', search: '?error=unauthorized' });
     }
     this.props.fetchUserInfo(tokenInfo);
   }

--- a/src/containers/SignIn.jsx
+++ b/src/containers/SignIn.jsx
@@ -52,15 +52,15 @@ class SignIn extends Component {
       // if there is a sign in error go to signin page without error message in url
       this.props.history.push('/');
     }
-  }
 
-  render() {
-    const error = localStorage.getItem('signInError');
-    if (error) {
+    if (localStorage.getItem('signInError')) {
       this.setState({
         signInError: true,
       });
     }
+  }
+
+  render() {
     return (
       <Fragment>
         <header className='signInHeader'>


### PR DESCRIPTION
**Description**
When an unauthenticated user attempts to access a protected route and are redirected to the Sign in page, they should see a notification stating `You must sign in with an Andela account`

**How to Test**
Ensure you are logged out of your Andela account. Then try accessing the /my-activities page directly by typing in the path in the browser url bar. You should be redirected to the Signin page and see the `You must sign in with an Andela account` notification. 