### PR TITLE
Resolves #61 -  Fix deployment errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Andela societies is an app that avails information about socities at Andela (Inv
 
 #### Installation requirements
 - [Node.js](https://nodejs.org/).
-- `npm` or `yarn`. In this guide we'll use `yarn`. Here is how to [install yarn](https://www.npmjs.com/package/yarn/tutorial).
+- `yarn`. Here is how to [install yarn](https://www.npmjs.com/package/yarn/tutorial).
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 
 **Important note:**
@@ -27,3 +27,7 @@ To test the app in watch mode, Run `yarn test:dev`. This listens to changes in y
 #### Other commands
 - `yarn build` builds the app for production.
 - `yarn serve` starts the app in production mode.
+
+#### Dev notice:
+**Package installation:**
+Use `yarn` to install packages. Do not install packages using `npm`. For more info, checkout this [issue](https://github.com/AndelaOSP/andela-societies-frontend/issues/61).

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "morgan": "^1.9.0",
     "node-sass": "^4.7.2",
     "prop-types": "^15.6.1",
-    "react": "^16.2.0",
+    "react": "^16.3.2",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,7 +2506,7 @@ eslint-plugin-jsx-a11y@^6.0.3:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^2.0.0"
 
-eslint-plugin-react@^7.5.1:
+eslint-plugin-react@^7.7.0:
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"
   dependencies:
@@ -5982,9 +5982,9 @@ react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
**Description**
Fix deployment errors caused by installing packages using `npm` instead of `yarn`.
**Fix**
I ran `yarn install`. This updated the `yarn.lock` file. 
I also added a notice in the README.md file to (hopefully) prevent this in future.
