### PR TITLE
#[157116995] Rework display of activity cards

### DIFF
--- a/src/assets/scss/ActivityCard.scss
+++ b/src/assets/scss/ActivityCard.scss
@@ -1,4 +1,5 @@
 @import '../../assets/scss/_mixins';
+@import '../../assets/scss/_vars'; 
 
 .activity {
   background: white;
@@ -52,6 +53,16 @@
   font-weight: normal;
   font-size: 1.7rem;
   margin: 0;
+}
+
+.activity__description__btn--more--less {
+  background: none;
+  padding: 0 auto;
+  border: none;
+  font: inherit;
+  color: $primary;
+  cursor: pointer;
+  outline: none;
 }
 
 .activity__footer {

--- a/src/assets/scss/MasonryLayout.scss
+++ b/src/assets/scss/MasonryLayout.scss
@@ -1,11 +1,11 @@
 .masonry-layout {
-  column-count: 2;
-  column-gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-gap: 1rem 1rem;
 }
 
 .masonry-layout__panel {
   break-inside: avoid;
-  padding-bottom: 1rem;
 }
 
 .masonry-layout__panel-content {

--- a/src/components/TruncateDescription.jsx
+++ b/src/components/TruncateDescription.jsx
@@ -1,0 +1,114 @@
+import React, { Component } from 'react';
+
+// third party libraries
+import PropType from 'prop-types';
+
+/**
+ * @summary Renders description
+ * @class TruncateDescription
+ * @extends React.Component
+ */
+class TruncateDescription extends Component {
+  /**
+    * @name propTypes
+    * @type {PropType}
+    * @param {String} description - The description to shorten
+    */
+  static propTypes = {
+    description: PropType.string.isRequired,
+  }
+
+  /**
+   * @name getDerivedStateFromProps
+   * @summary Lifecyle method that keeps description state in sync with props
+   * @param {Object} props
+   * @param {Object} state
+   */
+  static getDerivedStateFromProps(props, state) {
+    if (props.description !== state.description) {
+      return {
+        description: props.description,
+      };
+    }
+    return null;
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      description: this.props.description,
+      showMoreLess: false,
+      toggleBtnText: true,
+    };
+  }
+
+  componentDidMount() {
+    this.truncateDescription();
+  }
+
+  /**
+   * @name componentDidUpdate
+   * @summary Lifecycle method that is called when prop of description changes
+   * @param {Object} prevProps
+   * @param {Object} prevState
+   */
+  componentDidUpdate(prevProps) {
+    if (this.props.description !== prevProps.description) {
+      this.truncateDescription();
+    }
+  }
+
+  /**
+   * @name truncateDescription
+   * @summary Shortens the description passed as props
+   * @return {void}
+   */
+  truncateDescription = () => {
+    let longDescription = this.state.description;
+    longDescription = longDescription.trim();
+    let descArray = longDescription.split('');
+    if (descArray.length > 50) {
+      descArray = longDescription.split('', 50);
+      descArray = [...descArray, '...'];
+      return this.setState({ showMoreLess: true, description: descArray.join('') });
+    }
+    return null;
+  }
+
+  /**
+   * @name handleViewMoreLessClick
+   * @summary Handles showing of more or less text
+   * @return {void}
+   */
+  handleViewMoreLessClick = () => {
+    const { toggleBtnText } = this.state;
+    // console.log('here', this.state.description);
+    if (!toggleBtnText) {
+      this.truncateDescription();
+      this.setState({ toggleBtnText: !this.state.toggleBtnText });
+    } else {
+      this.setState({ description: this.props.description, toggleBtnText: !this.state.toggleBtnText });
+    }
+  }
+
+  render() {
+    const { description, showMoreLess, toggleBtnText } = this.state;
+    let showMoreLessHtml = null;
+
+    if (showMoreLess) {
+      showMoreLessHtml = (
+        <button className='activity__description__btn--more--less' onClick={this.handleViewMoreLessClick}>
+          {toggleBtnText ? 'More' : 'Less'}
+        </button>
+      );
+    }
+    return (
+      <p className='activity__description'>
+        {description}
+        {showMoreLessHtml}
+      </p>
+    );
+  }
+}
+
+export default TruncateDescription;

--- a/src/components/TruncateDescription.jsx
+++ b/src/components/TruncateDescription.jsx
@@ -10,69 +10,49 @@ import PropType from 'prop-types';
  */
 class TruncateDescription extends Component {
   /**
-    * @name propTypes
-    * @type {PropType}
-    * @param {String} description - The description to shorten
-    */
+   * @name propTypes
+   * @type {PropType}
+   * @param {String} description - The description to shorten
+   */
   static propTypes = {
     description: PropType.string.isRequired,
-  }
-
-  /**
-   * @name getDerivedStateFromProps
-   * @summary Lifecyle method that keeps description state in sync with props
-   * @param {Object} props
-   * @param {Object} state
-   */
-  static getDerivedStateFromProps(props, state) {
-    if (props.description !== state.description) {
-      return {
-        description: props.description,
-      };
-    }
-    return null;
   }
 
   constructor(props) {
     super(props);
     this.state = {
       description: this.props.description,
-      showMoreLess: false,
-      toggleBtnText: true,
+      longDescription: true,
     };
-  }
-
-  componentDidMount() {
-    this.truncateDescription();
   }
 
   /**
    * @name componentDidUpdate
    * @summary Lifecycle method that is called when prop of description changes
    * @param {Object} prevProps
-   * @param {Object} prevState
    */
   componentDidUpdate(prevProps) {
     if (this.props.description !== prevProps.description) {
-      this.truncateDescription();
+      return {
+        description: this.props.description,
+      };
     }
+    return null;
   }
 
   /**
    * @name truncateDescription
-   * @summary Shortens the description passed as props
-   * @return {void}
+   * @summary Shortens the description passed as a param
+   * @param {String} desc - description to be shortened
+   * @param {Boolean} longDescription - boolean value indicate if description is long
+   * @return {String} desc
    */
-  truncateDescription = () => {
-    let longDescription = this.state.description;
-    longDescription = longDescription.trim();
-    let descArray = longDescription.split('');
-    if (descArray.length > 50) {
-      descArray = longDescription.split('', 50);
-      descArray = [...descArray, '...'];
-      return this.setState({ showMoreLess: true, description: descArray.join('') });
+  truncateDescription = (desc, longDescription) => {
+    if (desc.trim().length > 50 && longDescription) {
+      const shortDesc = desc.slice(0, 51).concat('...');
+      return shortDesc;
     }
-    return null;
+    return desc;
   }
 
   /**
@@ -81,31 +61,25 @@ class TruncateDescription extends Component {
    * @return {void}
    */
   handleViewMoreLessClick = () => {
-    const { toggleBtnText } = this.state;
-    // console.log('here', this.state.description);
-    if (!toggleBtnText) {
-      this.truncateDescription();
-      this.setState({ toggleBtnText: !this.state.toggleBtnText });
-    } else {
-      this.setState({ description: this.props.description, toggleBtnText: !this.state.toggleBtnText });
-    }
+    const { longDescription } = this.state;
+    this.setState({ longDescription: !longDescription });
   }
 
   render() {
-    const { description, showMoreLess, toggleBtnText } = this.state;
-    let showMoreLessHtml = null;
+    const { description, longDescription } = this.state;
+    let buttonHtml = null;
 
-    if (showMoreLess) {
-      showMoreLessHtml = (
+    if (description.trim().length > 50) {
+      buttonHtml = (
         <button className='activity__description__btn--more--less' onClick={this.handleViewMoreLessClick}>
-          {toggleBtnText ? 'More' : 'Less'}
+          {longDescription ? 'More' : 'Less'}
         </button>
       );
     }
     return (
       <p className='activity__description'>
-        {description}
-        {showMoreLessHtml}
+        {this.truncateDescription(description, longDescription)}
+        {buttonHtml}
       </p>
     );
   }

--- a/src/components/activities/ActivityCard.jsx
+++ b/src/components/activities/ActivityCard.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropType from 'prop-types';
 
+import TruncateDescription from '../TruncateDescription';
 import Globe from '../svgIcons/activityIcons/Globe';
 
 /**
@@ -38,6 +39,7 @@ class ActivityCard extends Component {
     owner: null,
   };
   statuses = ['pending', 'rejected', 'approved', 'in review'];
+
   /**
    * @summary Renders the status indicator on the ActivityCard
    */
@@ -90,7 +92,7 @@ class ActivityCard extends Component {
             <span className='activity__date'>{date}</span>
           </div>
           <div className='activity__content'>
-            <h1 className='activity__description'>{description}</h1>
+            <TruncateDescription description={description} />
           </div>
           <div className='activity__footer'>
             {

--- a/src/containers/MasonryLayout.jsx
+++ b/src/containers/MasonryLayout.jsx
@@ -43,16 +43,12 @@ class MasonryLayout extends Component {
    * @returns React Elements containing ActivityCard for each activity
    */
   createItems = items => (
-    <div>
-      {
-        items.map(item => (
-          <div className='masonry-layout__panel' key={item.props.id}>
-            {item}
-          </div>
-        ))
-      }
-    </div>
-  )
+    items.map(item => (
+      <div className='masonry-layout__panel' key={item.props.id}>
+        {item}
+      </div>
+    ))
+  );
 
   /**
    * Render MasonryLayout Component

--- a/src/containers/VerifyActivities.jsx
+++ b/src/containers/VerifyActivities.jsx
@@ -84,7 +84,7 @@ class VerifyActivities extends Component {
                           id={activity.id}
                           category={activity.category}
                           date={(activity.date)}
-                          description={activity.activity}
+                          description={activity.description || activity.activity}
                           points={activity.points}
                           status={activity.status}
                           showUserDetails={showUserDetails}

--- a/src/containers/VerifyActivities.jsx
+++ b/src/containers/VerifyActivities.jsx
@@ -10,6 +10,7 @@ import Stats from '../components/sidebar/Stats';
 import stats from '../fixtures/stats';
 import { fetchSocietyInfo } from '../actions/societyInfoActions';
 import filterActivitiesByStatus from '../helpers/filterActivitiesByStatus';
+import dateFormatter from '../helpers/dateFormatter';
 
 class VerifyActivities extends Component {
   /**
@@ -79,17 +80,25 @@ class VerifyActivities extends Component {
                   :
                   <MasonryLayout
                     items={
-                      activities.map(activity => (
-                        <ActivityCard
-                          id={activity.id}
-                          category={activity.category}
-                          date={(activity.date)}
-                          description={activity.description || activity.activity}
-                          points={activity.points}
-                          status={activity.status}
+                      activities.map((activity) => {
+                        const {
+                          id,
+                          category,
+                          date,
+                          description,
+                          points,
+                          status,
+                        } = activity;
+                        return (<ActivityCard
+                          id={id}
+                          category={category}
+                          date={dateFormatter(date)}
+                          description={description || 'There is no description for this activity'}
+                          points={points}
+                          status={status}
                           showUserDetails={showUserDetails}
-                        />
-                      ))
+                        />);
+                      })
                     }
                   />
               }

--- a/src/fixtures/activity.js
+++ b/src/fixtures/activity.js
@@ -2,7 +2,7 @@ const activity = {
   id: '7387721305415687',
   category: 'Participating in a tech event',
   date: 'November 3, 2017',
-  description: 'Mentored teens how to code. (DBC 2016 at Redemption camp)',
+  description: 'Mentored teens how to code. (DBC 2016 at Redemption camp). Jim Shelton of ChanZuckerberginitiative sits down with Andela fellows',
   points: 250,
   status: 'default',
 };

--- a/tests/components/TruncateDescription.test.jsx
+++ b/tests/components/TruncateDescription.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+// third party libraries
+import { shallow } from 'enzyme';
+
+// components
+import TruncateDescription from '../../src/components/TruncateDescription';
+
+// fixtures
+import activity from '../../src/fixtures/activity'
+
+describe('<TruncateDescription />', () => {
+
+  const setUpWrapper = ({
+    description = activity.description,
+  } = {}) => {
+
+    const props = { description }
+    return shallow(<TruncateDescription {...props} />);
+  };
+
+  it('should render TruncateDescription', () => {
+    const shallowWrapper = setUpWrapper();
+    expect(shallowWrapper.length).toBe(1);
+  });
+
+  it('should show view more button when description is long', () => {
+    const shallowWrapper = setUpWrapper();
+    expect(shallowWrapper.find('.activity__description__btn--more--less').length).toBe(1);
+  });
+
+  it('should change state and button text to view less when view more is clicked', () => {
+    const shallowWrapper = setUpWrapper();
+    const viewMoreBtn = shallowWrapper.find('.activity__description__btn--more--less');
+    viewMoreBtn.simulate('click');
+    expect(shallowWrapper.state().toggleBtnText).toEqual(false);
+    expect(shallowWrapper.html()).toContain('Less');
+  });
+
+  it('should show description only when it is long', () => {
+    const shallowWrapper = setUpWrapper({ description: 'Lorem ipsum dolor sit amet.' });
+    expect(shallowWrapper.find('.activity__description').length).toBe(1);
+    expect(shallowWrapper.find('.activity__description__btn--more--less').length).toBe(0);
+  });
+});
+

--- a/tests/components/TruncateDescription.test.jsx
+++ b/tests/components/TruncateDescription.test.jsx
@@ -7,15 +7,13 @@ import { shallow } from 'enzyme';
 import TruncateDescription from '../../src/components/TruncateDescription';
 
 // fixtures
-import activity from '../../src/fixtures/activity'
+import activity from '../../src/fixtures/activity';
 
 describe('<TruncateDescription />', () => {
-
   const setUpWrapper = ({
     description = activity.description,
   } = {}) => {
-
-    const props = { description }
+    const props = { description };
     return shallow(<TruncateDescription {...props} />);
   };
 
@@ -33,13 +31,13 @@ describe('<TruncateDescription />', () => {
     const shallowWrapper = setUpWrapper();
     const viewMoreBtn = shallowWrapper.find('.activity__description__btn--more--less');
     viewMoreBtn.simulate('click');
-    expect(shallowWrapper.state().toggleBtnText).toEqual(false);
+    expect(shallowWrapper.state().longDescription).toEqual(false);
     expect(shallowWrapper.html()).toContain('Less');
   });
 
-  it('should show description only when it is long', () => {
+  it('should not show More button when description is short', () => {
     const shallowWrapper = setUpWrapper({ description: 'Lorem ipsum dolor sit amet.' });
-    expect(shallowWrapper.find('.activity__description').length).toBe(1);
+    expect(shallowWrapper.state().description).toEqual('Lorem ipsum dolor sit amet.');
     expect(shallowWrapper.find('.activity__description__btn--more--less').length).toBe(0);
   });
 });

--- a/tests/components/activities/ActivityCard.test.jsx
+++ b/tests/components/activities/ActivityCard.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import ActivityCard from '../../../src/components/activities/ActivityCard';
 import activity from '../../../src/fixtures/activity';
 
@@ -9,12 +9,18 @@ describe('<ActivityCard />', () => {
     <ActivityCard {...activity} />,
   );
 
+  const shallowWrapper = shallow(<ActivityCard {...activity} />);
+
   it('should render without crashing', () => {
     expect(wrapper).not.toThrowError();
   });
 
   it('should set default showUserDetails to false', () => {
     expect(wrapper().find('.activity__owner').length).toBe(0);
+  });
+
+  it('should render at least a description', () => {
+    expect(wrapper().find('.activity__description').length).toBe(1);
   });
 
   it('should show user details', () => {


### PR DESCRIPTION
#### What does this PR do?
Fixes the bug with the display of activity cards from Top to Bottom and have the card width spanning according to the text description. 
#### Description of Task to be completed?
* Have cards flowing from left to right
* Modify height of cards to make them equal
* Create a method to have the description shortened to fit the height of the card.
* Have view more and less functionality for cards with long description
#### How should this be manually tested?
`git clone` this repo or pull this branch, `cd` into `andela-societies-frontend`, `yarn install`. Navigate to `My Activities` or `Verify activities`.
#### What are the relevant pivotal tracker stories?
[157116995](https://www.pivotaltracker.com/story/show/157116995)
#### Screenshots (if appropriate)
![screen shot 2018-05-28 at 10 27 48 2](https://user-images.githubusercontent.com/29278184/40602706-3f3c1714-6262-11e8-99d7-fc1410fade2f.png)
