### PR TITLE
Resolves #158124097 Conditionally display input field on the log activity form

### DIFF
--- a/src/assets/scss/FormField.scss
+++ b/src/assets/scss/FormField.scss
@@ -27,7 +27,6 @@
  flex: 1;
  height: 5rem;
  outline: none;
- margin-top: 2rem;
  font-size: large;
  border:0.1rem solid #eeeeee;
  border-radius: 0.5rem;
@@ -114,7 +113,6 @@
   font: normal normal normal 1.8rem/1 FontAwesome;
   color: black;
   right: 8rem;
-  top: 3rem;
   padding: 1rem 0rem 0rem 1rem;
   border-left: 0.1rem solid #eeeeeeee;
   position: absolute;
@@ -124,7 +122,8 @@
 
 .activityCategory select {
   -webkit-appearance: none;
-  -moz-appearance: none; 
+  -moz-appearance: none;
+  appearance: none;
   display: block;
   flex: 1;
   max-width: 100%;

--- a/src/fixtures/categories.js
+++ b/src/fixtures/categories.js
@@ -4,6 +4,7 @@ const categories = [
     id: 'id1',
     name: 'Bootcamp Interviews',
     value: 20,
+    supportsMultipleParticipants: 1,
   },
   {
     description: 'Participating in a press interview for Andela marketing',

--- a/src/fixtures/labels.js
+++ b/src/fixtures/labels.js
@@ -1,0 +1,6 @@
+const labels = {
+  interviewees: ['bootcamp interviews'],
+  mentees: ['mentoring', 'external mentoring'],
+};
+
+export default labels;

--- a/tests/containers/forms/LogActivityForm.test.jsx
+++ b/tests/containers/forms/LogActivityForm.test.jsx
@@ -19,6 +19,7 @@ const defaultState = {
   description: '',
   errors: [],
   message: null,
+  numberOf: '',
 };
 
 const event = { preventDefault: () => {} };
@@ -53,12 +54,12 @@ describe('<LogActivityForm />', () => {
   });
 
   it('should show the <SingleInput/> component when it has loaded', () => {
-    wrapper.setState({ selectValue: 'eef0e594-43cd-11e8-87a7-9801a7ae0329' });
+    wrapper.setState({ activityTypeId: 'id1' });
     expect(wrapper.find('SingleInput').length).toEqual(1);
   });
 
   it('should render the SingleInput with the correct label', () => {
-    wrapper.setState({ selectValue: 'eef0e594-43cd-11e8-87a7-9801a7ae0329' });
+    wrapper.setState({ activityTypeId: 'id1' });
     expect(wrapper.find('SingleInput').dive().find('.formField__label').text()).toEqual('# of interviewees');
   });
 
@@ -121,8 +122,10 @@ describe('<LogActivityForm />', () => {
       createActivity={() => { }}
     />);
     const instance = mounted.instance();
+    jest.spyOn(instance, 'selectedCategory');
+    instance.selectedCategory();
     instance.setState({
-      activityTypeId: 'asd78sad8ads8ad7',
+      activityTypeId: 'id1',
       date: '2018-12-12',
     }, () => {
       instance.resetState();
@@ -153,5 +156,13 @@ describe('<LogActivityForm />', () => {
     jest.spyOn(instance, 'renderValidationError');
     instance.handleAddEvent(event, 'date');
     expect(instance.renderValidationError).toHaveBeenCalled();
+  });
+
+  it('should add numberOf to errors fields if is not set when bootcamp interviews is selected', () => {
+    const instance = wrapper.instance();
+    jest.spyOn(instance, 'handleAddEvent');
+    wrapper.setState({ activityTypeId: 'id1' });
+    instance.handleAddEvent(event);
+    expect(instance.state.errors).toContain('numberOf');
   });
 });


### PR DESCRIPTION
[Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/158124097)

## Description
Currently, when society members selects `Bootcamp interviews` as an activity category, they do not have access to an input field to enter the number of interviewees. This PR fixes that.

## Fix
Display a input field to for number of interviewees when the `Bootcamp interviews` category is selected

## How to test
You should see the `# of interviewees` field when `Bootcamp interviews` is selected as the category

## Screenshots

<img width="914" alt="screen shot 2018-06-07 at 09 30 09" src="https://user-images.githubusercontent.com/13675851/41082034-9c3ba7d8-6a35-11e8-85d7-79c5c3243e6e.png">

<img width="902" alt="screen shot 2018-06-07 at 09 31 07" src="https://user-images.githubusercontent.com/13675851/41082036-a0531428-6a35-11e8-8506-241e985d1c10.png">

<img width="899" alt="screen shot 2018-06-07 at 09 31 20" src="https://user-images.githubusercontent.com/13675851/41082040-a440224c-6a35-11e8-86b7-efffbcecf669.png">

