### PR TITLE
Resolves[158591325] protect routes by user roles

### DIFF
--- a/src/components/routes/PrivateRoute.jsx
+++ b/src/components/routes/PrivateRoute.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+import { hasAllowedRole } from '../../helpers/authentication';
+
+/**
+ * @name PrivateRoute
+ * @param {Object} props - React PropTypes
+ * @return Route component
+ */
+const PrivateRoute = ({ component: Component, ...rest }) => (
+  <Route
+    {...rest}
+    render={props => (
+      hasAllowedRole(rest.userRoles, rest.allowedRoles) ?
+        <Component {...props} /> :
+        <Redirect to='/' />
+    )}
+  />
+);
+
+PrivateRoute.propTypes = {
+  component: PropTypes.func.isRequired,
+};
+
+export default PrivateRoute;

--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -50,7 +50,11 @@ const Sidebar = ({ userRoles }) => (
 
 
 Sidebar.propTypes = {
-  userRoles: PropTypes.arrayOf(PropTypes.string).isRequired,
+  userRoles: PropTypes.arrayOf(PropTypes.string),
+};
+
+Sidebar.defaultProps = {
+  userRoles: [],
 };
 
 export default Sidebar;

--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 import logo from '../../assets/images/logos/andelaLogoWhite.png';
 import pageInfo from '../../helpers/pageInfo';
+import { hasAllowedRole } from '../../helpers/authentication';
 
 /**
  * @name renderMenuItem
@@ -23,7 +25,7 @@ const renderMenuItem = pageInfoData => (
  * @summary Sidebar component
  * @return React node containing the sidebar component
  */
-const Sidebar = () => (
+const Sidebar = ({ userRoles }) => (
   <aside className='sidebar'>
     <header className='sidebar__header'>
       <span className='sidebar__logoWrapper' style={{ backgroundImage: `url(${logo})` }} />
@@ -31,7 +33,12 @@ const Sidebar = () => (
     </header>
     <nav className='sidebar__nav'>
       <div className='sidebar__navGroup'>
-        {pageInfo.pages.map(renderMenuItem)}
+        {pageInfo.pages.map((page) => {
+          if (page.allowedRoles) {
+            return hasAllowedRole(userRoles, page.allowedRoles) && renderMenuItem(page);
+          }
+          return renderMenuItem(page);
+        })}
       </div>
       <div className='sidebar__navGroup'>
         <span className='sidebar__navGroupHeader'>Societies</span>
@@ -40,5 +47,10 @@ const Sidebar = () => (
     </nav>
   </aside>
 );
+
+
+Sidebar.propTypes = {
+  userRoles: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
 
 export default Sidebar;

--- a/src/constants/roles.js
+++ b/src/constants/roles.js
@@ -1,0 +1,3 @@
+export const SOCIETY_SECRETARY = 'secretary';
+export const SUCCESS_OPS = 'success ops';
+export const SOCIETY_PRESIDENT = 'president';

--- a/src/containers/Page.jsx
+++ b/src/containers/Page.jsx
@@ -139,14 +139,18 @@ class Page extends Component {
 
   render() {
     const {
-      userInfo, societyInfo, profile, updating,
+      userInfo,
+      societyInfo,
+      profile,
+      updating,
     } = this.props;
+    const userRoles = Object.keys(profile.roles);
 
     return (
       <Fragment>
         <div className='headerBackground' />
         <div className='sidebarWrapper sidebarWrapper--sidebarOpen'>
-          <Sidebar />
+          <Sidebar userRoles={userRoles} />
         </div>
         <main className='mainPage mainPage--sidebarOpen'>
           {this.isASocietyPage() ? <SocietyBanner society={societyInfo.info} /> : null}

--- a/src/containers/Router.jsx
+++ b/src/containers/Router.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import Signin from '../containers/SignIn';
 import pageInfo from '../helpers/pageInfo';
-
+import PrivateRoute from '../components/routes/PrivateRoute';
 
 /**
  * @name Router
@@ -12,22 +14,40 @@ import pageInfo from '../helpers/pageInfo';
  */
 const pages = [...pageInfo.pages, ...pageInfo.societyPages];
 
-const Router = () => (
+const Router = ({ profile }) => (
   <BrowserRouter>
     <Switch>
       <Route path='/' exact component={Signin} />
       {
         pages.map(pageInfoData => (
-          <Route
-            path={pageInfoData.url}
-            exact
-            component={pageInfoData.component}
-            key={pageInfoData.title}
-          />
+          pageInfoData.allowedRoles ?
+            <PrivateRoute
+              path={pageInfoData.url}
+              exact
+              component={pageInfoData.component}
+              key={pageInfoData.title}
+              allowedRoles={pageInfoData.allowedRoles}
+              userRoles={profile.roles && Object.keys(profile.roles)}
+            />
+            :
+            <Route
+              path={pageInfoData.url}
+              exact
+              component={pageInfoData.component}
+              key={pageInfoData.title}
+            />
         ))
       }
     </Switch>
-  </BrowserRouter>
+  </BrowserRouter>);
+
+const mapStateToProps = state => ({
+  profile: state.userProfile.info,
+}
 );
 
-export default Router;
+Router.propTypes = {
+  profile: PropTypes.shape({}).isRequired,
+};
+
+export default connect(mapStateToProps)(Router);

--- a/src/fixtures/store.js
+++ b/src/fixtures/store.js
@@ -42,6 +42,7 @@ const store = {
       society: {
         name: '',
       },
+      roles: {},
     },
     error: {},
   },

--- a/src/fixtures/userProfile.js
+++ b/src/fixtures/userProfile.js
@@ -12,6 +12,9 @@ const testProfile = {
     id: '-Kkh3MFLCBgVTSZ4s-de',
     name: 'SocietyName',
   },
+  roles: {
+    secretary: '-Kabc',
+  },
 };
 
 export default testProfile;

--- a/src/helpers/authentication.js
+++ b/src/helpers/authentication.js
@@ -96,3 +96,12 @@ export const isFellow = (tokenInfo) => {
     return false;
   }
 };
+
+/**
+ * @name hasAllowedRole
+ * @summary checks if user role is amongst allowed roles
+ * @return {boolean} whether user role is amongst allowed roles
+ */
+export const hasAllowedRole = (userRoles, allowedRoles) => (
+  userRoles.some(role => allowedRoles.includes(role))
+);

--- a/src/helpers/pageInfo.js
+++ b/src/helpers/pageInfo.js
@@ -30,12 +30,14 @@ const pageInfo = {
       url: '/u/verify-activities',
       component: VerifyActivities,
       menuIcon: VerifyActivitiesIcon,
+      allowedRoles: ['secretary', 'success', 'success ops'],
     },
     {
       title: 'Redemptions',
       url: '/u/redemptions',
       component: Redemptions,
       menuIcon: RedemptionsIcon,
+      allowedRoles: ['president', 'success', 'success ops'],
     },
   ],
   societyPages: [

--- a/src/helpers/pageInfo.js
+++ b/src/helpers/pageInfo.js
@@ -10,6 +10,7 @@ import IstelleIcon from '../components/svgIcons/societyIcons/Istelle';
 import SparksIcon from '../components/svgIcons/societyIcons/Sparks';
 import PhoenixIcon from '../components/svgIcons/societyIcons/Phoenix';
 import Redemptions from '../containers/Redemptions';
+import { SOCIETY_SECRETARY, SUCCESS_OPS, SOCIETY_PRESIDENT } from '../constants/roles';
 
 const pageInfo = {
   pages: [
@@ -30,14 +31,14 @@ const pageInfo = {
       url: '/u/verify-activities',
       component: VerifyActivities,
       menuIcon: VerifyActivitiesIcon,
-      allowedRoles: ['secretary', 'success', 'success ops'],
+      allowedRoles: [SUCCESS_OPS, SOCIETY_SECRETARY],
     },
     {
       title: 'Redemptions',
       url: '/u/redemptions',
       component: Redemptions,
       menuIcon: RedemptionsIcon,
-      allowedRoles: ['president', 'success', 'success ops'],
+      allowedRoles: [SUCCESS_OPS, SOCIETY_PRESIDENT],
     },
   ],
   societyPages: [

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -35,6 +35,7 @@ const initialState = {
       society: {
         name: '',
       },
+      roles: {},
     },
     error: {},
   },

--- a/tests/components/routes/PrivateRoute.test.jsx
+++ b/tests/components/routes/PrivateRoute.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils';
+import { MemoryRouter } from 'react-router-dom';
+
+import PrivateRoute from '../../../src/components/routes/PrivateRoute';
+import VerifyActivities from '../../../src/containers/VerifyActivities';
+import storeFixture from '../../../src/fixtures/store';
+import { SOCIETY_SECRETARY, SUCCESS_OPS } from '../../../src/constants/roles';
+import profile from '../../../src/fixtures/userProfile';
+
+const store = createMockStore(storeFixture);
+
+const pageInfoData = {
+  title: 'Verify Activities',
+  url: '/u/verify-activities',
+  component: VerifyActivities,
+  allowedRoles: [SUCCESS_OPS, SOCIETY_SECRETARY],
+};
+
+describe('<PrivateRoute />', () => {
+  it('should render without crashing', () => {
+    expect(mount
+      .bind(null, <Provider
+        store={store}
+      >
+        <MemoryRouter>
+          <PrivateRoute
+            path={pageInfoData.url}
+            exact
+            component={pageInfoData.component}
+            key={pageInfoData.title}
+            allowedRoles={pageInfoData.allowedRoles}
+            userRoles={profile.roles && Object.keys(profile.roles)}
+          />
+        </MemoryRouter>
+      </Provider>)).not.toThrow();
+  });
+});

--- a/tests/containers/Page.test.jsx
+++ b/tests/containers/Page.test.jsx
@@ -24,6 +24,9 @@ describe('<Page />', () => {
         society: {
           name: 'iStelle',
         },
+        roles: {
+          president: '-Kabc',
+        },
       },
       userInfo: {
         name: 'test test',

--- a/tests/containers/Router.test.jsx
+++ b/tests/containers/Router.test.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils';
+
 import Router from '../../src/containers/Router';
+import storeFixture from '../../src/fixtures/store';
+
+const store = createMockStore(storeFixture);
 
 describe('<Router />', () => {
   it('should render without crashing', () => {
-    expect(mount.bind(null, <Router />)).not.toThrow();
+    expect(mount.bind(null, <Provider store={store}><Router /></Provider>)).not.toThrow();
   });
 });


### PR DESCRIPTION
[Pivotal Tracker story](https://www.pivotaltracker.com/story/show/158591325)

## Description
This PR adds functionality to ensure that pages such as verify activities and redemptions page are only accessed by users with the required roles

## How to test
- `/verify-activities` should only be accessed by users with **secretary**, **success** or **success ops** roles
- `/redemptions` should only be accessed by users with **president**, **success** or **success ops** roles
- Any attempt to access the protected routes by users without the required roles should redirect them to the home page `/`