### PR TITLE
[Feature] add a home page to act as a loading screen

### DIFF
--- a/src/assets/scss/Loader.scss
+++ b/src/assets/scss/Loader.scss
@@ -1,0 +1,37 @@
+
+.loader {
+  width: 8rem;
+  height: 8rem;
+  border-radius: 100%;
+  position: relative;
+  margin-left: 28rem;
+
+  &:before {
+    content: "";
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 10rem;
+    border-radius: 100%;
+    border: 1rem solid transparent;
+    border-top-color: $andelaBlue;
+    z-index: 100;
+    animation: spin .8s ease-out infinite;
+  }
+}
+
+@keyframes spin{
+  0%{
+    -webkit-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100%{
+    -webkit-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -28,3 +28,4 @@
 @import 'Tab';
 @import 'loaders';
 @import 'LinearLayout';
+@import 'Loader';

--- a/src/components/header/Breadcrumb.jsx
+++ b/src/components/header/Breadcrumb.jsx
@@ -1,16 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+
 /**
  * @name Breadcrumb
  * @summary Renders the Breadcrumb in the header section
  */
 const Breadcrumb = (props) => {
   const breadcrumbLinkClass = props.pageInfo.url.split('/')[1] === 'society' ? 'breadcrumb__link--white' : '';
+
+  let titleHtml = '';
+  if (props.pageInfo.title.toLowerCase() !== 'home') {
+    titleHtml = props.pageInfo.title;
+  }
+
   return (
     <div className='breadcrumb'>
-      <a href='/' className={`breadcrumb__link ${breadcrumbLinkClass}`}>Dashboard</a>
-      <a href={props.pageInfo.url} className={`breadcrumb__link ${breadcrumbLinkClass}`}>{props.pageInfo.title}</a>
+      <Link to='/u/' className={`breadcrumb__link ${breadcrumbLinkClass}`}>Dashboard</Link>
+      <Link to={props.pageInfo.url} className={`breadcrumb__link ${breadcrumbLinkClass}`}>
+        {titleHtml}
+      </Link>
     </div>
   );
 };

--- a/src/components/loaders/Loader.jsx
+++ b/src/components/loaders/Loader.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * @name Loader
+ * @summary Renders a spinner during API calls to fetch data
+ * @returns {React.Element} to display a loader
+ */
+const Loader = () => (
+  <div className='loader-wrapper'>
+    <div className='loader' />
+  </div>);
+
+export default Loader;

--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import logo from '../../assets/images/logos/andelaLogoWhite.png';
-import pageInfo from '../../helpers/pageInfo';
 import { hasAllowedRole } from '../../helpers/authentication';
 
 /**
@@ -25,7 +24,7 @@ const renderMenuItem = pageInfoData => (
  * @summary Sidebar component
  * @return React node containing the sidebar component
  */
-const Sidebar = ({ userRoles }) => (
+const Sidebar = ({ userRoles, pageInfo }) => (
   <aside className='sidebar'>
     <header className='sidebar__header'>
       <span className='sidebar__logoWrapper' style={{ backgroundImage: `url(${logo})` }} />
@@ -34,6 +33,9 @@ const Sidebar = ({ userRoles }) => (
     <nav className='sidebar__nav'>
       <div className='sidebar__navGroup'>
         {pageInfo.pages.map((page) => {
+          if (page.title.toLowerCase() === 'home') {
+            return null;
+          }
           if (page.allowedRoles) {
             return hasAllowedRole(userRoles, page.allowedRoles) && renderMenuItem(page);
           }
@@ -51,10 +53,12 @@ const Sidebar = ({ userRoles }) => (
 
 Sidebar.propTypes = {
   userRoles: PropTypes.arrayOf(PropTypes.string),
+  pageInfo: PropTypes.shape({}),
 };
 
 Sidebar.defaultProps = {
   userRoles: [],
+  pageInfo: {},
 };
 
 export default Sidebar;

--- a/src/constants/roles.js
+++ b/src/constants/roles.js
@@ -10,3 +10,11 @@ export const SOCIETY_PRESIDENT = 'society president';
 export const STAFF_USERS = [CIO, SUCCESS_OPS, SUCCESS];
 export const VERIFICATION_USERS = [SOCIETY_SECRETARY, SUCCESS_OPS, CIO];
 
+export const ROLES = {
+  1: FELLOW,
+  2: SOCIETY_SECRETARY,
+  3: SOCIETY_PRESIDENT,
+  4: SUCCESS_OPS,
+  5: CIO,
+};
+

--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -1,0 +1,120 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+// components
+import Page from './Page';
+import Loader from '../components/loaders/Loader';
+
+// actions
+import { fetchUserProfile } from '../actions/userProfileActions';
+
+// helpers
+import { getUserInfo, hasAllowedRole } from '../helpers/authentication';
+
+// constants
+import { ROLES } from '../constants/roles';
+
+class Home extends Component {
+  /**
+   * @name Home
+   * @type {propTypes}
+   * @property {Function} fetchUserProfile -fetches user profile info
+   * @property {Object} history - route history
+   * @return React node containing component for displaying the Home page
+   */
+  static propTypes = {
+    fetchUserProfile: PropTypes.func.isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func,
+    }),
+  };
+
+  static defaultProps = {
+    history: {},
+  };
+
+  /**
+   * @name getDerivedStateFromProps
+   * @summary react life cycle to update state with prop values
+   * @return {Object} new state values
+   */
+  static getDerivedStateFromProps = props => ({
+    profile: props.profile,
+  });
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true,
+      profile: null,
+    };
+  }
+
+  /**
+   * @name componentDidMount
+   * @summary run fetchUserProfile right after the component is mounted
+   */
+  componentDidMount() {
+    const userId = getUserInfo() && getUserInfo().id;
+    this.props.fetchUserProfile(userId);
+  }
+
+  /**
+   * @name componentDidUpdate
+   * @summary check if user roles are present and runs navigate
+   */
+  componentDidUpdate() {
+    const { profile } = this.state;
+
+    if (Object.keys(profile).length) {
+      this.navigate(profile);
+    }
+  }
+
+  /**
+   * @name navigate
+   * @param {Object} profile - contains user roles
+   * @summary navigates user to path depending on user roles
+   */
+  navigate = (profile) => {
+    const { push } = this.props.history;
+    if (hasAllowedRole(Object.keys(profile.roles), [ROLES[4]])) {
+      push({ pathname: '/u/verify-activities' });
+    } else if (hasAllowedRole(Object.keys(profile.roles), [ROLES[5]])) {
+      push({ pathname: '/u/redemptions' });
+    } else if (hasAllowedRole(Object.keys(profile.roles), [ROLES[1]])) {
+      push({ pathname: '/u/my-activities' });
+    }
+  };
+
+  /**
+   * @name renderLoader
+   * @summary display loader if loading state value is true
+   * @returns {React.Node} loader or empty string
+   */
+  renderLoader = () => {
+    let loaderHtml = '';
+    if (this.state.loading) {
+      loaderHtml = <Loader />;
+    }
+    return loaderHtml;
+  }
+
+  render() {
+    return (
+      <Page>
+        {this.renderLoader()}
+      </Page>);
+  }
+}
+
+const mapStateToProps = state => ({
+  profile: state.userProfile.info,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchUserProfile: userId => dispatch(fetchUserProfile(userId)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Home);

--- a/src/containers/MyActivities.jsx
+++ b/src/containers/MyActivities.jsx
@@ -7,6 +7,8 @@ import PageHeader from '../components/header/PageHeader';
 import MasonryLayout from '../containers/MasonryLayout';
 import ActivityCard from '../components/activities/ActivityCard';
 import Stats from '../components/sidebar/Stats';
+import Loader from '../components/loaders/Loader';
+
 import { fetchMyActivities } from '../actions/myActivitiesActions';
 import { fetchCategories } from '../actions/categoriesActions';
 import dateFormatter from '../helpers/dateFormatter';
@@ -105,7 +107,7 @@ class MyActivities extends Component {
             <div className='activities'>
               {
                 requesting ?
-                  <h3>Loading... </h3>
+                  <Loader />
                   :
                   <MasonryLayout
                     items={

--- a/src/containers/Page.jsx
+++ b/src/containers/Page.jsx
@@ -25,6 +25,7 @@ import {
   setSignInError, decodeToken, getUserInfo,
   hasAllowedRole,
 } from '../helpers/authentication';
+import pageInfo from '../helpers/pageInfo';
 
 /**
  * @name Page
@@ -175,7 +176,7 @@ class Page extends Component {
       <Fragment>
         <div className='headerBackground' />
         <div className='sidebarWrapper sidebarWrapper--sidebarOpen'>
-          <Sidebar userRoles={userRoles} />
+          <Sidebar userRoles={userRoles} pageInfo={pageInfo} />
         </div>
         <main className='mainPage mainPage--sidebarOpen'>
           {this.isASocietyPage() ? <SocietyBanner society={societyInfo.info} /> : null}
@@ -194,7 +195,7 @@ class Page extends Component {
         </main>
         {this.renderModal()}
         {
-          this.state.showModal || hasAllowedRole(userRoles, STAFF_USERS) ?
+          this.state.showModal || hasAllowedRole(userRoles, STAFF_USERS) || userRoles.length === 0 ?
             ''
             : <FloatingButton onClick={this.onFabClick} />
         }

--- a/src/containers/Redemptions.jsx
+++ b/src/containers/Redemptions.jsx
@@ -11,6 +11,7 @@ import PageHeader from '../components/header/PageHeader';
 import MasonryLayout from '../containers/MasonryLayout';
 import Stats from '../components/sidebar/Stats';
 import ErrorMessage from '../common/ErrorMessage';
+import Loader from '../components/loaders/Loader';
 
 // thunk
 import { fetchRedemption } from '../actions/redeemPointsAction';
@@ -249,7 +250,7 @@ class Redemptions extends React.Component {
     } = this.state;
 
     if (requesting) {
-      return (<h3>Loading... </h3>);
+      return (<Loader />);
     } else if (!requesting && !filteredActivities.length) {
       return (
         <ErrorMessage

--- a/src/containers/SignIn.jsx
+++ b/src/containers/SignIn.jsx
@@ -7,7 +7,7 @@ import RedemptionIcon from '../components/svgIcons/menuIcons/Redemptions';
 import SocietiesIcon from '../components/svgIcons/menuIcons/Societies';
 import LogActivitiesIcon from '../components/svgIcons/menuIcons/LogActivities';
 import config from '../../config';
-import { getToken, tokenIsValid, isFellow, setSignInError, decodeToken } from '../helpers/authentication';
+import { getToken, tokenIsValid, setSignInError, decodeToken } from '../helpers/authentication';
 import ErrorIcon from '../components/svgIcons/notificationIcons/Error';
 import logo from '../assets/images/logos/andelaLogoBlue.png';
 
@@ -43,9 +43,9 @@ class SignIn extends Component {
     // retrieve token from cookie
     const token = getToken();
     const tokenInfo = decodeToken(token);
-    if (token && tokenIsValid(tokenInfo) && isFellow(tokenInfo)) {
+    if (token && tokenIsValid(tokenInfo)) {
       localStorage.removeItem('signInError');
-      this.props.history.push('/u/my-activities');
+      this.props.history.push('/u/');
     } else {
       localStorage.removeItem('signInError');
       setSignInError();

--- a/src/containers/VerifyActivities.jsx
+++ b/src/containers/VerifyActivities.jsx
@@ -14,6 +14,7 @@ import PageHeader from '../components/header/PageHeader';
 import MasonryLayout from '../containers/MasonryLayout';
 import LinearLayout from '../containers/LinearLayout';
 import Stats from '../components/sidebar/Stats';
+import Loader from '../components/loaders/Loader';
 import stats from '../fixtures/stats';
 import { fetchSocietyInfo } from '../actions/societyInfoActions';
 import { verifyActivity, verifyActivitiesOps } from '../actions/verifyActivityActions';
@@ -245,7 +246,7 @@ class VerifyActivities extends Component {
             <div className='activities'>
               {
                 requesting ?
-                  <h3 className='loader'>Loading... </h3>
+                  <Loader />
                   :
                   this.renderLayout()
               }
@@ -257,7 +258,7 @@ class VerifyActivities extends Component {
             stats={stats}
           />
         </aside>
-        { snackBarMessage }
+        {snackBarMessage}
       </Page>
     );
   }

--- a/src/helpers/pageInfo.js
+++ b/src/helpers/pageInfo.js
@@ -1,3 +1,4 @@
+import Home from '../containers/Home';
 import MyActivities from '../containers/MyActivities';
 import Society from '../containers/Society';
 import VerifyActivities from '../containers/VerifyActivities';
@@ -22,8 +23,8 @@ const pageInfo = {
   pages: [
     {
       title: 'Home',
-      url: '/u/my-activities',
-      component: MyActivities,
+      url: '/u/',
+      component: Home,
       menuIcon: HomeIcon,
     },
     {

--- a/tests/components/header/Header.test.jsx
+++ b/tests/components/header/Header.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { createMockStore } from 'redux-test-utils';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 
 import Header from '../../../src/components/header/Header';
 import { nonFellowTokenInfo } from '../../__mocks__/tokenInfoMock';
@@ -14,11 +15,13 @@ const history = { push: () => { } };
 const mounted = mount.bind(
   null,
   <Provider store={store}>
-    <Header
-      userInfo={nonFellowTokenInfo.UserInfo}
-      history={history}
-      profile={testProfile}
-    />
+    <MemoryRouter>
+      <Header
+        userInfo={nonFellowTokenInfo.UserInfo}
+        history={history}
+        profile={testProfile}
+      />
+    </MemoryRouter>
   </Provider>,
 );
 describe('<Header />', () => {

--- a/tests/components/sidebar/Sidebar.test.jsx
+++ b/tests/components/sidebar/Sidebar.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+
+import Sidebar from '../../../src/components/sidebar/Sidebar';
+import testProfile from '../../../src/fixtures/userProfile';
+import pageInfo from '../../../src/helpers/pageInfo';
+import Home from '../../../src/containers/Home';
+import HomeIcon from '../../../src/components/svgIcons/menuIcons/Home';
+
+const userProfile = { ...testProfile, roles: { 'society president': 'Kabc' } };
+const testPageInfo = { ...pageInfo };
+const testPage = {
+  title: 'Test',
+  url: '/u/',
+  component: Home,
+  menuIcon: HomeIcon,
+};
+testPageInfo.pages.push(testPage);
+
+let mountWrapper;
+
+describe('<Sidebar>', () => {
+  beforeEach(() => {
+    mountWrapper = mount((
+      <MemoryRouter>
+        <Sidebar userRoles={Object.keys(userProfile.roles)} pageInfo={testPageInfo} />
+      </MemoryRouter>
+    ));
+  });
+
+  it('should render without error', () => {
+    expect(mountWrapper.length).toBe(1);
+  });
+});

--- a/tests/containers/Home.test.jsx
+++ b/tests/containers/Home.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import { createMockStore } from 'redux-test-utils';
+import { MemoryRouter } from 'react-router-dom';
+import storeFixture from '../../src/fixtures/store';
+
+import Home from '../../src/containers/Home';
+import testProfile from '../../src/fixtures/userProfile';
+
+const store = createMockStore(storeFixture);
+
+let mountedWrapper;
+let shallowWrapper;
+
+describe('<Home />', () => {
+  beforeEach(() => {
+    mountedWrapper = mount((
+      <Provider store={store} >
+        <MemoryRouter>
+          <Home />
+        </MemoryRouter>
+      </Provider>
+    ));
+
+    shallowWrapper = shallow((
+      <Home.WrappedComponent fetchUserProfile={jest.fn()} history={{ push: jest.fn() }} />
+    ));
+  });
+
+  it('should render without crashing', () => {
+    expect(mountedWrapper.length).toBe(1);
+  });
+
+  it('should render a loader', () => {
+    expect(mountedWrapper.find('.loader').length).toBe(1);
+  });
+
+  it('should navigate cio user to the redemptions page', () => {
+    const cioProfile = { ...testProfile, roles: { CIO: 'Kabc' } };
+    const instance = shallowWrapper.instance();
+    jest.spyOn(instance, 'navigate');
+    instance.navigate(cioProfile);
+    expect(instance.props.history.push).toBeCalledWith({ pathname: '/u/redemptions' });
+  });
+
+  it('should navigate success ops user to the verify activities page', () => {
+    const successOpsProfile = { ...testProfile, roles: { 'success ops': 'Kabc' } };
+    const instance = shallowWrapper.instance();
+    jest.spyOn(instance, 'navigate');
+    instance.navigate(successOpsProfile);
+    expect(instance.props.history.push).toBeCalledWith({ pathname: '/u/verify-activities' });
+  });
+
+  it('should navigate fellow user to the my activities page', () => {
+    const successOpsProfile = { ...testProfile, roles: { fellow: 'Kabc' } };
+    const instance = shallowWrapper.instance();
+    jest.spyOn(instance, 'navigate');
+    instance.navigate(successOpsProfile);
+    expect(instance.props.history.push).toBeCalledWith({ pathname: '/u/my-activities' });
+  });
+});
+

--- a/tests/containers/MyActivities.test.jsx
+++ b/tests/containers/MyActivities.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { createMockStore } from 'redux-test-utils';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
@@ -9,23 +9,44 @@ import storeFixture from '../../src/fixtures/store';
 
 const store = createMockStore(storeFixture);
 const history = { push: () => { } };
+const fetchUserInfo = jest.fn();
+const changePageTitle = jest.fn();
+const fetchActivities = jest.fn();
+const fetchCategories = jest.fn();
+
 const mounted = mount.bind(
   null,
   <Provider store={store}>
     <MemoryRouter>
       <MyActivities
         history={history}
-        fetchUserInfo={() => {}}
-        changePageTitle={() => {}}
-        fetchActivities={() => {}}
+        fetchUserInfo={fetchUserInfo}
+        changePageTitle={changePageTitle}
+        fetchActivities={fetchActivities}
       />
     </MemoryRouter>
   </Provider>,
 );
-
+let shallowWrapper;
 
 describe('<MyActivities />', () => {
+  beforeEach(() => {
+    shallowWrapper = shallow(<MyActivities.WrappedComponent
+      history={history}
+      fetchUserInfo={fetchUserInfo}
+      changePageTitle={changePageTitle}
+      fetchActivities={fetchActivities}
+      fetchCategories={fetchCategories}
+      categories={[]}
+    />);
+  });
+
   it('should render without crashing', () => {
     expect(mounted).not.toThrow();
+  });
+
+  it('should render loader when requesting activities', () => {
+    shallowWrapper.setProps({ requesting: true });
+    expect(shallowWrapper.find('Loader').length).toBe(1);
   });
 });

--- a/tests/containers/Redemptions.test.jsx
+++ b/tests/containers/Redemptions.test.jsx
@@ -39,12 +39,13 @@ const setUpWrapper = ({
     requesting,
     hasError,
   };
-  return mount(
+  return mount((
     <Provider store={store}>
       <MemoryRouter>
         <Redemptions.WrappedComponent {...props} />
       </MemoryRouter>
-    </Provider>);
+    </Provider>
+  ));
 };
 
 let shallowWrapper;
@@ -85,9 +86,9 @@ describe('<Redemptions />', () => {
     expect(mountedWrapper.find('.error-message').length).toBe(1);
   });
 
-  it('should render an Loading... text when requesting is true', () => {
+  it('should render a loader when requesting is true', () => {
     const mountedWrapper = setUpWrapper({ requesting: true });
-    expect(mountedWrapper.find('.activities').html()).toContain('Loading...');
+    expect(mountedWrapper.find('.loader').length).toBe(1);
   });
 
   it('should filter redemptions given status', () => {

--- a/tests/containers/VerifyActivities.test.jsx
+++ b/tests/containers/VerifyActivities.test.jsx
@@ -81,6 +81,6 @@ describe('<VerifyActivities />', () => {
 
   it('should show loader when fetching', () => {
     component.setProps({ requesting: true });
-    expect(component.find('.loader').length).toBe(1);
+    expect(component.find('Loader').length).toBe(1);
   });
 });


### PR DESCRIPTION
### Resolves [#158915792](https://www.pivotaltracker.com/story/show/158915792)

## Description
Replace MyActivities page as the home page by adding a homepage component that serves as a loading screen when a user logs in before being navigated to restricted pages once user roles have been fetched from the API. 

## How to test
Once logged in, you should see a loading page before being redirected
Redirect logic according to role:
- Fellow/society secretary/society president -> MyActivities page 
- Success ops -> VerifyActivities page 
- CIO -> Redemptions page 

## Screenshots

<img width="1136" alt="screen shot 2018-07-10 at 17 00 31" src="https://user-images.githubusercontent.com/13675851/42514803-ecbe0ca4-8462-11e8-81f2-42a0aa4d1086.png">
