### PR TITLE
 #158894695 Display View for Verify Activities For Success Op Users & Social Secretaries

### DIFF
--- a/tests/components/activities/ActivityCard.test.jsx
+++ b/tests/components/activities/ActivityCard.test.jsx
@@ -9,7 +9,6 @@ const { EDIT } = clickActions;
 
 const showCheckBox = true;
 
-
 describe('<ActivityCard />', () => {
   const handleClick = jest.fn();
   const props = {


### PR DESCRIPTION
## Description
This PR display the view for the verified Activities from societies in **pending** state that need to be verified by a success op team member.  This also displays activities that are **in review** for the individual social secretaries for each society so they can approve them ready for the success-op team.

## How to test
Once logged in as either a social secretary or a success op member
Navigate to Verify Activities tab on the Sidebar
- You should view a list of activities in either pending state for all societies or in review for social secretaries.

## Screenshots

**Success-Op user view**
<img width="1280" alt="screen shot 2018-07-12 at 1 18 35 pm" src="https://user-images.githubusercontent.com/26222856/42632816-5f2c31a2-85d6-11e8-80ad-7d8f41c9c59c.png">

**Social Secretary user view**
<img width="1280" alt="screen shot 2018-07-12 at 1 19 36 pm" src="https://user-images.githubusercontent.com/26222856/42632817-5f554614-85d6-11e8-80b4-32b11feb7d6b.png">
