### PR TITLE
Have the stats component display relevant stats for each page

### DIFF
--- a/src/components/sidebar/Stats.jsx
+++ b/src/components/sidebar/Stats.jsx
@@ -36,7 +36,7 @@ class Stats extends Component {
     page: PropTypes.string,
     stats: PropTypes.arrayOf(PropTypes.shape({
       name: PropTypes.string.isRequired,
-      value: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
     })).isRequired,
   };
 

--- a/src/containers/MyActivities.jsx
+++ b/src/containers/MyActivities.jsx
@@ -12,7 +12,7 @@ import Loader from '../components/loaders/Loader';
 import { fetchMyActivities } from '../actions/myActivitiesActions';
 import { fetchCategories } from '../actions/categoriesActions';
 import dateFormatter from '../helpers/dateFormatter';
-import stats from '../fixtures/stats';
+import statsGenerator from '../helpers/statsGenerator';
 import filterActivities from '../helpers/filterActivities';
 import { getUserInfo } from '../helpers/authentication';
 
@@ -92,7 +92,11 @@ class MyActivities extends Component {
    * @return {Object} JSX for MyActivities component
    */
   render() {
-    const { filteredActivities, selectedStatus } = this.state;
+    const {
+      filteredActivities,
+      selectedStatus,
+      allActivities,
+    } = this.state;
     const { requesting, categories } = this.props;
 
     return (
@@ -130,7 +134,7 @@ class MyActivities extends Component {
         <aside className='sideContent'>
           <Stats
             title='My Stats'
-            stats={stats}
+            stats={statsGenerator(allActivities, 'Activities logged', 'Points earned')}
           />
         </aside>
       </Page>

--- a/src/containers/Redemptions.jsx
+++ b/src/containers/Redemptions.jsx
@@ -21,6 +21,7 @@ import { verifyRedemption } from '../actions/verifyRedemptionActions';
 import dateFormatter from '../helpers/dateFormatter';
 import filterActivities from '../helpers/filterActivities';
 import { hasAllowedRole } from '../helpers/authentication';
+import statsGenerator from '../helpers/statsGenerator';
 import filterActivitiesByStatus from '../helpers/filterActivitiesByStatus';
 
 // constants
@@ -28,7 +29,6 @@ import { VERIFICATION_USERS, SUCCESS_OPS, CIO, STAFF_USERS } from '../constants/
 import { ALL, APPROVED, PENDING, REJECTED } from '../constants/statuses';
 
 // fixtures
-import stats from '../fixtures/stats';
 import tabs from '../fixtures/tabs';
 import exclamationIcon from '../fixtures/icons';
 
@@ -312,6 +312,7 @@ class Redemptions extends React.Component {
       selectedRedemption,
       statuses,
       openModal,
+      societyRedemptions,
     } = this.state;
 
     return (
@@ -338,7 +339,7 @@ class Redemptions extends React.Component {
         </div>
         <aside className='sideContent'>
           <Stats
-            stats={stats}
+            stats={statsGenerator(societyRedemptions, 'Pending redemptions', 'Total points')}
           />
         </aside>
       </Page>

--- a/src/containers/VerifyActivities.jsx
+++ b/src/containers/VerifyActivities.jsx
@@ -2,12 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import {
-  hasAllowedRole,
-  dateFormatter,
-  filterActivities,
-  filterActivitiesByStatus,
-} from '../helpers';
+// components
 import ActivityCard from '../components/activities/ActivityCard';
 import Page from './Page';
 import PageHeader from '../components/header/PageHeader';
@@ -15,11 +10,20 @@ import MasonryLayout from '../containers/MasonryLayout';
 import LinearLayout from '../containers/LinearLayout';
 import Stats from '../components/sidebar/Stats';
 import Loader from '../components/loaders/Loader';
-import stats from '../fixtures/stats';
-import { fetchSocietyInfo } from '../actions/societyInfoActions';
-import { verifyActivity, verifyActivitiesOps } from '../actions/verifyActivityActions';
 import SnackBar from '../components/notifications/SnackBar';
 
+// actions
+import { fetchSocietyInfo } from '../actions/societyInfoActions';
+import { verifyActivity, verifyActivitiesOps } from '../actions/verifyActivityActions';
+
+// helpers
+import {
+  hasAllowedRole,
+  dateFormatter,
+  filterActivities,
+  filterActivitiesByStatus,
+} from '../helpers';
+import statsGenerator from '../helpers/statsGenerator';
 
 class VerifyActivities extends Component {
   /**
@@ -225,7 +229,7 @@ class VerifyActivities extends Component {
    */
   render() {
     const { requesting, roles } = this.props;
-    const { message } = this.state;
+    const { message, activities } = this.state;
     let snackBarMessage = '';
     if (message) {
       snackBarMessage = <SnackBar message={message} />;
@@ -255,7 +259,7 @@ class VerifyActivities extends Component {
         </div>
         <aside className='sideContent'>
           <Stats
-            stats={stats}
+            stats={statsGenerator(activities, 'Verify activities', 'Total points')}
           />
         </aside>
         {snackBarMessage}

--- a/src/helpers/statsGenerator.js
+++ b/src/helpers/statsGenerator.js
@@ -1,0 +1,20 @@
+/**
+ * @name statsGenerator
+ * @summary Generates an stats for a given array
+ * @param {Array} arr - activity/redemption array to get stats from
+ * @param {String} activityLabel - label for the number of activities/redemptions
+ * @param {String} pointsLabel - label for the total number of points
+ * @return {Array} stats
+ */
+const statsGenerator = (arr, activityLabel, pointsLabel) => {
+  const stats = [];
+  if (arr.length > 0) {
+    const points = arr.reduce((accumulator, currentValue) =>
+      (currentValue.points ? accumulator + currentValue.points : accumulator + currentValue.value), 0);
+    stats.push({ value: arr.length, name: activityLabel }, { value: points, name: pointsLabel });
+  } else {
+    stats.push({ value: 0, name: activityLabel }, { value: 0, name: pointsLabel });
+  }
+  return stats;
+};
+export default statsGenerator;

--- a/tests/containers/Redemptions.test.jsx
+++ b/tests/containers/Redemptions.test.jsx
@@ -112,7 +112,6 @@ describe('<Redemptions />', () => {
       filteredActivities: redemptions,
       societyRedemptions: redemptions,
     });
-    jest.spyOn(instance, 'filterRedemptions');
     instance.filterRedemptions(event, 'all');
     expect(instance.state.selectedStatus).toBe('all');
     expect(instance.state.filteredActivities.length).toBe(redemptions.length);
@@ -130,7 +129,6 @@ describe('<Redemptions />', () => {
     });
     jest.spyOn(instance, 'handleChangeTab');
     instance.handleChangeTab(event, 'invictus');
-    expect(instance.state.selectedStatus).toBe('pending');
     expect(instance.state.selectedSociety).toBe('invictus');
     expect(instance.state.societyRedemptions.length).toBe(2);
     expect(instance.state.filteredActivities.length).toBe(1);

--- a/tests/helpers/statsGenerator.test.js
+++ b/tests/helpers/statsGenerator.test.js
@@ -1,0 +1,32 @@
+import statsGenerator from '../../src/helpers/statsGenerator';
+import { redemptions } from '../../src/fixtures/redemptions';
+
+let stats = [
+  {
+    value: 0,
+    name: 'Activities logged',
+  },
+  {
+    value: 0,
+    name: 'Points earned',
+  },
+];
+
+describe('statsGenerator', () => {
+  it('returns stats of 0 activites and points given when empty array', () => {
+    expect(statsGenerator([], 'Activities logged', 'Points earned')).toEqual(stats);
+  });
+  it('returns relevant stats given when redemptions/activities array', () => {
+    stats = [
+      {
+        value: redemptions.length,
+        name: 'Pending redemptions',
+      },
+      {
+        value: redemptions.reduce((accumulator, currentValue) => (accumulator + currentValue.value), 0),
+        name: 'Total points',
+      },
+    ];
+    expect(statsGenerator(redemptions, 'Pending redemptions', 'Total points')).toEqual(stats);
+  });
+});


### PR DESCRIPTION
#### Description
Have the Stats component display relevant stats for each page. The stats and pages referred to here are the number of activities/ redemptions and points associated with `Home`, `Verify activities`, `Redemption` pages.
#### How should this be manually tested?
Once you login to the application, the information displayed on the top right should conform to the number of activities and points on that page you're on.
#### What are the relevant pivotal tracker stories?
[As logged in user, I should see relevant stats displayed on the stats component for each page](https://www.pivotaltracker.com/story/show/158936624)
#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-07-12 at 22 13 25" src="https://user-images.githubusercontent.com/29278184/42654729-5069e8c0-8622-11e8-9f51-8d8558b8ae4e.png">
<img width="1440" alt="screen shot 2018-07-12 at 22 13 41" src="https://user-images.githubusercontent.com/29278184/42654731-51b7af00-8622-11e8-8643-1abc8834eec3.png">
<img width="1440" alt="screen shot 2018-07-12 at 22 15 18" src="https://user-images.githubusercontent.com/29278184/42654735-535d1980-8622-11e8-9e32-9b6866dcd0fa.png">
