### PR TITLE
[159036599] Fixes displaying appropriate stats on Redemptions page when logged in as society president

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,7 +2,7 @@ const configs = {
   production: {
     AUTH_API: 'https://api.andela.com/login?redirect_url=',
     APP_URL: 'https://societies.andela.com',
-    API_BASE_URL: 'https://api-societies.andela.com/api/v1',
+    API_BASE_URL: 'https://societies-api.andela.com/api/v1',
   },
   staging: {
     AUTH_API: 'https://api.andela.com/login?redirect_url=',

--- a/src/containers/Redemptions.jsx
+++ b/src/containers/Redemptions.jsx
@@ -312,7 +312,6 @@ class Redemptions extends React.Component {
       selectedRedemption,
       statuses,
       openModal,
-      societyRedemptions,
     } = this.state;
 
     return (
@@ -339,7 +338,7 @@ class Redemptions extends React.Component {
         </div>
         <aside className='sideContent'>
           <Stats
-            stats={statsGenerator(societyRedemptions, 'Pending redemptions', 'Total points')}
+            stats={statsGenerator(filteredActivities, 'Pending redemptions', 'Total points')}
           />
         </aside>
       </Page>


### PR DESCRIPTION
 #### Description
Have the stats component display appropriate stats on Redemptions page when logged in as a `society president`

#### How can this be manually tested?
Once you login to the application, i.e. as a `society president`, while on the `Redemptions page` the `Pending redemptions` and `Total points` should be equal to the number of activities and points on that page.
#### Relevant pivotal tracker stories
[Fixes showing relevant details on the stats component on the Redemptions page when logged in as a society president.](https://www.pivotaltracker.com/story/show/159036599)

#### Screenshot(s)
<img width="1440" alt="screen shot 2018-07-13 at 23 09 29" src="https://user-images.githubusercontent.com/29278184/42712149-27dc25a4-86f3-11e8-9505-b24dedcf8da3.png">