### PR TITLE
Add loader to society page

### DIFF
--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -113,8 +113,4 @@ const mapStateToProps = state => ({
   profile: state.userProfile.info,
 });
 
-const mapDispatchToProps = dispatch => ({
-  fetchUserProfile: userId => dispatch(fetchUserProfile(userId)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Home);
+export default connect(mapStateToProps, { fetchUserProfile })(Home);

--- a/src/containers/MyActivities.jsx
+++ b/src/containers/MyActivities.jsx
@@ -109,10 +109,9 @@ class MyActivities extends Component {
               selectedStatus={selectedStatus}
             />
             <div className='activities'>
+              { requesting && <Loader /> }
               {
-                requesting ?
-                  <Loader />
-                  :
+                !requesting &&
                   <MasonryLayout
                     items={
                       filteredActivities.map(activity => (

--- a/src/containers/Society.jsx
+++ b/src/containers/Society.jsx
@@ -90,6 +90,7 @@ class Society extends Component {
         showUserDetails,
       } = this.state;
       const { societyInfo } = this.props;
+      const { requesting } = societyInfo;
       return (
         <Page>
           <div className='mainContent'>
@@ -100,26 +101,24 @@ class Society extends Component {
                 filterActivities={this.filterActivities}
               />
               <div className='activities'>
-                {
-                  societyInfo.requesting ?
-                    <Loader />
-                    :
-                    <MasonryLayout
-                      items={
-                        filteredActivities.map(activity => (
-                          <ActivityCard
-                            id={activity.id}
-                            category={activity.category}
-                            date={dateFormatter(activity.date)}
-                            description={activity.activity}
-                            points={activity.points}
-                            status={activity.status}
-                            showUserDetails={showUserDetails}
-                            owner={activity.owner}
-                          />
-                        ))
-                      }
-                    />
+                { requesting && <Loader /> }
+                { !requesting &&
+                  <MasonryLayout
+                    items={
+                      filteredActivities.map(activity => (
+                        <ActivityCard
+                          id={activity.id}
+                          category={activity.category}
+                          date={dateFormatter(activity.date)}
+                          description={activity.activity}
+                          points={activity.points}
+                          status={activity.status}
+                          showUserDetails={showUserDetails}
+                          owner={activity.owner}
+                        />
+                      ))
+                    }
+                  />
                 }
               </div>
             </div>
@@ -155,7 +154,6 @@ class Society extends Component {
 
 const mapStateToProps = state => ({
   societyInfo: state.societyInfo,
-  requesting: state.societyInfo.requesting,
 });
 
 export default connect(mapStateToProps, null)(Society);

--- a/src/containers/Society.jsx
+++ b/src/containers/Society.jsx
@@ -9,6 +9,7 @@ import MasonryLayout from '../containers/MasonryLayout';
 import Stats from '../components/sidebar/Stats';
 import filterActivities from '../helpers/filterActivities';
 import dateFormatter from '../helpers/dateFormatter';
+import Loader from '../components/loaders/Loader';
 
 /**
  * @name Society
@@ -88,6 +89,7 @@ class Society extends Component {
         selectedStatus,
         showUserDetails,
       } = this.state;
+      const { societyInfo } = this.props;
       return (
         <Page>
           <div className='mainContent'>
@@ -98,22 +100,27 @@ class Society extends Component {
                 filterActivities={this.filterActivities}
               />
               <div className='activities'>
-                <MasonryLayout
-                  items={
-                    filteredActivities.map(activity => (
-                      <ActivityCard
-                        id={activity.id}
-                        category={activity.category}
-                        date={dateFormatter(activity.date)}
-                        description={activity.activity}
-                        points={activity.points}
-                        status={activity.status}
-                        showUserDetails={showUserDetails}
-                        owner={activity.owner}
-                      />
-                    ))
-                  }
-                />
+                {
+                  societyInfo.requesting ?
+                    <Loader />
+                    :
+                    <MasonryLayout
+                      items={
+                        filteredActivities.map(activity => (
+                          <ActivityCard
+                            id={activity.id}
+                            category={activity.category}
+                            date={dateFormatter(activity.date)}
+                            description={activity.activity}
+                            points={activity.points}
+                            status={activity.status}
+                            showUserDetails={showUserDetails}
+                            owner={activity.owner}
+                          />
+                        ))
+                      }
+                    />
+                }
               </div>
             </div>
           </div>
@@ -148,6 +155,7 @@ class Society extends Component {
 
 const mapStateToProps = state => ({
   societyInfo: state.societyInfo,
+  requesting: state.societyInfo.requesting,
 });
 
 export default connect(mapStateToProps, null)(Society);

--- a/src/fixtures/store.js
+++ b/src/fixtures/store.js
@@ -50,6 +50,7 @@ const store = {
     requesting: false,
     activities: [],
     error: null,
+    updating: false,
   },
   redeemPointsInfo: {
     message: {},

--- a/tests/containers/SignIn.test.jsx
+++ b/tests/containers/SignIn.test.jsx
@@ -23,7 +23,10 @@ describe('<SignIn />', () => {
   });
 
   it('should have initial state property signInError as false', () => {
+    const history = { push: () => ('/u') };
+    wrapper = shallow(<SignIn.WrappedComponent history={history} />);
     expect(wrapper.instance().state).toHaveProperty('signInError', false);
+    expect(wrapper.render().find('.signInError').length).toBe(0);
   });
 
   it('should display signInError notification when signInError is true', () => {

--- a/tests/reducers/allActivitiesReducer.test.js
+++ b/tests/reducers/allActivitiesReducer.test.js
@@ -1,6 +1,3 @@
-// initial state
-import initialState from '../../src/reducers/initialState';
-
 // actions
 import {
   fetchAllActivitiesFailure,
@@ -29,56 +26,61 @@ import activity from '../../src/fixtures/activity';
 import info, { approvedActivities } from '../../src/fixtures/society';
 import store from '../../src/fixtures/store';
 
-const defaultState = initialState.allActivities;
 let expectedOutput;
 const error = new Error('Request failed with status code 400');
 
 describe('All activities reducer', () => {
+  const initialState = store.allActivities;
+
+  it('should set default initial state', () => {
+    expect(allActivities(undefined, {})).toEqual(initialState);
+  });
+
   it('should return default initial state when no action is provided', () => {
-    expect(allActivities(defaultState, {})).toEqual(defaultState);
+    expect(allActivities(initialState, {})).toEqual(initialState);
   });
 
   it('should return requesting state true when FETCH_ALL_ACTIVITIES_REQUEST action is fired ', () => {
     expectedOutput = {
-      ...defaultState,
+      ...initialState,
       requesting: true,
     };
-    expect(allActivities(defaultState, fetchAllActivitiesRequests())).toEqual(expectedOutput);
+    expect(allActivities(initialState, fetchAllActivitiesRequests())).toEqual(expectedOutput);
   });
 
   it('should handle FETCH_ALL_ACTIVITIES_SUCCESS case', () => {
     expectedOutput = {
-      ...defaultState,
+      ...initialState,
       requesting: false,
       activities,
     };
-    expect(allActivities(defaultState, fetchAllActivitiesSuccess(activities))).toEqual(expectedOutput);
+    expect(allActivities(initialState, fetchAllActivitiesSuccess(activities))).toEqual(expectedOutput);
   });
 
   it('should handle FETCH_ALL_ACTIVITIES_FAILURE case', () => {
     expectedOutput = {
-      ...defaultState,
+      ...initialState,
       requesting: false,
       error,
     };
-    expect(allActivities(defaultState, fetchAllActivitiesFailure(error))).toEqual(expectedOutput);
+    expect(allActivities(initialState, fetchAllActivitiesFailure(error))).toEqual(expectedOutput);
   });
 
   it('should handle VERIFY_ACTIVITY_REQUEST', () => {
-    expect(allActivities(defaultState, {
+    expect(allActivities(initialState, {
       type: VERIFY_ACTIVITY_REQUEST,
     })).toEqual({
-      ...defaultState,
+      ...initialState,
       updating: true,
     });
   });
 
   it('should handle VERIFY_ACTIVITY_FAILURE', () => {
-    expect(allActivities(defaultState, {
+    expect(allActivities(initialState, {
       type: VERIFY_ACTIVITY_FAILURE,
       error: { error: 404 },
     })).toEqual({
-      ...defaultState,
+      ...initialState,
       updating: false,
       error: { error: 404 },
       activities: store.societyActivities.activities,
@@ -86,42 +88,40 @@ describe('All activities reducer', () => {
   });
 
   it('should handle VERIFY_ACTIVITY_SUCCESS', () => {
-    defaultState.activities = info.loggedActivities;
-    defaultState.activities.push(activity);
+    initialState.activities = info.loggedActivities;
+    initialState.activities.push(activity);
     activity.status = 'pending';
     const newActivities = info.loggedActivities;
-    expect(allActivities(defaultState, {
+    expect(allActivities(initialState, {
       type: VERIFY_ACTIVITY_SUCCESS,
       activity,
     })).toEqual({
-      ...defaultState,
+      ...initialState,
       updating: false,
       activities: newActivities,
     });
   });
 
   it('should handle VERIFY_ACTIVITY_OPS_REQUEST', () => {
-    const expectedOutput = {
-      ...defaultState,
-      updating: true
+    expectedOutput = {
+      ...initialState,
+      updating: true,
     };
-    expect(allActivities(defaultState, { type: VERIFY_ACTIVITY_OPS_REQUEST })).toEqual(expectedOutput);
+    expect(allActivities(initialState, { type: VERIFY_ACTIVITY_OPS_REQUEST })).toEqual(expectedOutput);
   });
 
   it('should handle VERIFY_ACTIVITY_OPS_FAILURE', () => {
-    const expectedOutput = {
-      ...defaultState,
+    expectedOutput = {
+      ...initialState,
       error,
     };
-    expect(allActivities(defaultState, verifyActivitiesOpsFailure(error))).toEqual(expectedOutput);
+    expect(allActivities(initialState, verifyActivitiesOpsFailure(error))).toEqual(expectedOutput);
   });
 
   it('should handle VERIFY_ACTIVITY_OPS_SUCCESS', () => {
     const activityIds = ['bnfad176-43cd-11e8-b3b9-9801a7ae0329'];
-    defaultState.activities = info.loggedActivities;
-    const result = allActivities(defaultState, verifyActivitiesOpsSuccess(approvedActivities, activityIds));
+    initialState.activities = info.loggedActivities;
+    const result = allActivities(initialState, verifyActivitiesOpsSuccess(approvedActivities, activityIds));
     expect(result.activities[0]).toEqual(approvedActivities[0]);
   });
 });
-
-

--- a/tests/reducers/commentsReducer.test.js
+++ b/tests/reducers/commentsReducer.test.js
@@ -19,6 +19,10 @@ let expectedState;
 const error = 'Error encountered while submitting your comment. Try again';
 
 describe('Comments Reducer tests', () => {
+  it('should set default initial state', () => {
+    expect(commentsReducer(undefined, {})).toEqual(defaultState);
+  });
+
   it('should return the default state when given no action ', () => {
     expect(commentsReducer(defaultState, {})).toEqual(defaultState);
   });

--- a/tests/reducers/myActivitiesReducer.test.js
+++ b/tests/reducers/myActivitiesReducer.test.js
@@ -14,6 +14,10 @@ import store from '../../src/fixtures/store';
 describe('myActivitiesReducer', () => {
   const initialState = store.myActivities;
 
+  it('should set default initial state', () => {
+    expect(myActivitiesReducer(undefined, {})).toEqual(initialState);
+  });
+
   it('should return the initial state when the action is not handled', () => {
     expect(myActivitiesReducer(initialState, { type: 'DOES_NOT_EXIST' })).toEqual(initialState);
   });


### PR DESCRIPTION
#### What does this PR do?
 Adds loader to the society page.

#### Description of Task to be completed?
When a user visits the society page, a loader should be displayed before activities are fully populated to the page.

##### Any background context you want to provide?
N/A

##### What are the relevant Pivotal Tracker stories?
[159430139](https://www.pivotaltracker.com/story/show/159430139)

##### Questions?
N/A

#### Any background context you want to provide?
N/A

What does this PR do?
Refactors URLs for the services to review, approve, reject logged activities by a society secretary or success ops member
