### PR TITLE
Fixes bug when displaying redemptions when logged in as a president's society

### DIFF
--- a/src/components/header/PageHeader.jsx
+++ b/src/components/header/PageHeader.jsx
@@ -5,6 +5,10 @@ import PropType from 'prop-types';
 import Button from '../../common/Button';
 import Tabs from '../../components/header/Tabs';
 
+// constants
+import { STATUSES } from '../../constants/statuses';
+
+// helpers
 import capitalizeString from '../../helpers/stringFormatter';
 
 /**
@@ -23,8 +27,6 @@ class PageHeader extends Component {
    * @property {Object} statuses - Array of status types
    * @property {Boolean} showTabs - Whether or not to show tabs
    * @property {Function} handleChangeTab - called when a tab is clicked
-   * @property {Function} filterRedemptions - Returns a list of redemptions depending on selected tab
-   * @property {Function} changeFilterHandler - filters redemptions by tab
    * @property {Function} selectAllClick - prop to toggle state of selectAllChecked
    */
   static propTypes = {
@@ -33,11 +35,8 @@ class PageHeader extends Component {
     hideFilter: PropType.bool,
     showSelectAllApproveBtn: PropType.bool,
     tabs: PropType.arrayOf(PropType.string),
-    statuses: PropType.arrayOf(PropType.string),
     showTabs: PropType.bool,
     handleChangeTab: PropType.func,
-    filterRedemptions: PropType.func,
-    changeFilterHandler: PropType.func,
     filterActivities: PropType.func,
     handleSelectAllClick: PropType.func,
     handleApproveAllClick: PropType.func,
@@ -56,12 +55,9 @@ class PageHeader extends Component {
     showSelectAllApproveBtn: false,
     showTabs: false,
     tabs: [],
-    statuses: ['All', 'In review', 'Pending', 'Rejected', 'Approved'],
     handleSelectAllClick: () => { },
     handleApproveAllClick: () => { },
-    changeFilterHandler: () => { },
     handleChangeTab: () => { },
-    filterRedemptions: () => { },
   };
 
   /**
@@ -128,7 +124,6 @@ class PageHeader extends Component {
       showFilterOptionsDropdown,
       activeClass,
     } = this.state;
-    const { statuses } = this.props;
     return (
       <div className='filterOptions'>
         <button
@@ -143,21 +138,17 @@ class PageHeader extends Component {
         )}
         >
           {
-            statuses.map(status => (
+            Object.keys(STATUSES).map(status => (
               <div
                 key={status}
                 onMouseDown={(e) => {
-                  if (this.props.changeFilterHandler()) {
-                    this.props.filterRedemptions(e, status);
-                  } else {
-                    this.props.filterActivities(e.currentTarget.textContent);
-                  }
+                  this.props.filterActivities(e.currentTarget.textContent);
                 }}
-                className={`filterOptions__option ${selectedStatus === status ? activeClass : ''}`}
+                className={`filterOptions__option ${selectedStatus === STATUSES[status] ? activeClass : ''}`}
                 role='button'
                 tabIndex='0'
               >
-                {status && capitalizeString(status)}
+                {STATUSES[status] && capitalizeString(STATUSES[status])}
               </div>
             ))
           }

--- a/src/fixtures/redemptions.js
+++ b/src/fixtures/redemptions.js
@@ -88,7 +88,7 @@ export const redemptions = Array(3).fill({}).map((el, index) => ({
       name: 'Invictus',
     },
     roles: {
-      president: 'sec1234abc',
+      'society president': 'sec1234abc',
     },
   },
 

--- a/tests/components/header/PageHeader.test.jsx
+++ b/tests/components/header/PageHeader.test.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
+// components
 import PageHeader from '../../../src/components/header/PageHeader';
 
+// constants
+import { STATUSES } from '../../../src/constants/statuses';
+
+// helpers
+import capitalizeString from '../../../src/helpers/stringFormatter';
+
 const props = {
-  changeFilterHandler: jest.fn(),
   filterActivities: jest.fn(),
   filterRedemptions: jest.fn(),
   handleChangeTab: jest.fn(),
@@ -12,7 +18,6 @@ const props = {
   selectedSociety: 'istelle',
   selectedStatus: 'All',
   showTabs: false,
-  statuses: ['All', 'In review', 'Pending', 'Rejected', 'Approved'],
   tabs: [],
   title: 'Invictus',
   handleApproveAllClick: () => {},
@@ -20,17 +25,10 @@ const props = {
   showSelectAllApproveBtn: false,
 };
 
-const status = {
-  activeClass: 'filterOptions__option--active',
-  statuses: ['All', 'In review', 'Pending', 'Rejected', 'Approved'],
-};
-
 const wrapper = shallow(<PageHeader {...props} />);
+let capitalizedStatus;
 
 describe('<PageHeader />', () => {
-  wrapper.setState({
-    statuses: status.statuses,
-  });
   it('should have props passed to it', () => {
     expect(wrapper.instance().props).toEqual(props);
   });
@@ -40,19 +38,22 @@ describe('<PageHeader />', () => {
   });
 
   it('should display activity option filters', () => {
-    expect(wrapper.find('.filterOptions__option').length).toBe(status.statuses.length);
+    const statuses = Object.keys(STATUSES);
+    expect(wrapper.find('.filterOptions__option').length).toBe(statuses.length);
   });
 
   it('should display selected status as `selectedStatus`', () => {
     wrapper.setState({
-      selectedStatus: status.statuses[2],
+      selectedStatus: STATUSES[2],
     });
-    expect(wrapper.find('.filterOptions__button').text()).toBe(status.statuses[2]);
+    capitalizedStatus = capitalizeString(STATUSES[2]);
+    expect(wrapper.find('.filterOptions__button').text()).toBe(capitalizedStatus);
   });
   it('should `tick` against the selected option', () => {
     wrapper.setState({
-      selectedStatus: status.statuses[1],
+      selectedStatus: STATUSES[1],
     });
-    expect(wrapper.find(`.${status.activeClass}`).text()).toBe(status.statuses[1]);
+    capitalizedStatus = capitalizeString(STATUSES[1]);
+    expect(wrapper.find('.filterOptions__option--active').text()).toBe(capitalizedStatus);
   });
 });


### PR DESCRIPTION
##### What does this PR do?
Fixes the bug on successful loading of the redemptions page, it displays redemptions for all societies.

##### Description of Task to be completed?
On successful loading of the redemptions page, it displays redemptions belonging to president's society.
* Filter redemptions based on the president's society.
* Filter redemptions based on the selected society in the navigation tabs when logged in as a success ops member or CIO.
* Modify `filterRedemptions` function to be used by the PageHeader to filter redemptions based on a status

##### What are the relevant Pivotal Tracker stories?
[159518063](https://www.pivotaltracker.com/story/show/159518063)

#### Screenshots
## Society President view of redemptions
<img width="1440" alt="screen shot 2018-08-06 at 4 13 11 pm" src="https://user-images.githubusercontent.com/29278184/43718639-e969159e-9993-11e8-9380-05a4f6a278fb.png">

## CIO view of redemptions when using the filter component
<img width="1440" alt="screen shot 2018-08-06 at 4 12 11 pm" src="https://user-images.githubusercontent.com/29278184/43718710-1bb53104-9994-11e8-9e50-168caffec787.png">
<img width="1440" alt="screen shot 2018-08-06 at 4 12 22 pm" src="https://user-images.githubusercontent.com/29278184/43718711-1ce6b8ea-9994-11e8-9b11-fdaebdbdfa45.png">



