### PR TITLE
Fixes success/error messages showing when using RedeemPoints form

### DIFF
--- a/src/actions/verifyActivityActions.js
+++ b/src/actions/verifyActivityActions.js
@@ -9,7 +9,6 @@ import {
   VERIFY_ACTIVITY_OPS_SUCCESS,
 } from '../types';
 import config from '../../config';
-import { APPROVED } from '../constants/statuses';
 
 /**
  * @function verifyActivityRequest
@@ -106,8 +105,8 @@ export const verifyActivitiesOps = activityIds => (
   (dispatch) => {
     dispatch(verifyActivitiesOpsRequest());
     return http.put(
-      `${config.API_BASE_URL}/logged-activities/approve/`,
-      { loggedActivitiesIds: activityIds, status: APPROVED },
+      `${config.API_BASE_URL}/approve/logged-activities/`,
+      { loggedActivitiesIds: activityIds },
     )
       .then((response) => {
         dispatch(verifyActivitiesOpsSuccess(response.data.data, activityIds));

--- a/src/components/notifications/SnackBar.jsx
+++ b/src/components/notifications/SnackBar.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import CloseIcon from '../svgIcons/notificationIcons/Close';
 import ErrorIcon from '../svgIcons/notificationIcons/Error';
 
+// Constants
+import SNACKBARTIMEOUT from '../../constants/snackbarTimeout';
+
 class SnackBar extends Component {
   /**
     * @name SnackBar
@@ -60,7 +63,7 @@ class SnackBar extends Component {
   showClass = () => {
     const { message } = this.state;
     if (message.type === 'success') {
-      setTimeout(() => { this.setState({ show: false }); }, 3000);
+      setTimeout(() => { this.setState({ show: false }); }, SNACKBARTIMEOUT);
     }
 
     return message ? `snackbar snackbar--show ${message.type}` : '';

--- a/src/constants/snackbarTimeout.js
+++ b/src/constants/snackbarTimeout.js
@@ -1,0 +1,3 @@
+const SNACKBARTIMEOUT = 3000;
+
+export default SNACKBARTIMEOUT;

--- a/src/containers/Page.jsx
+++ b/src/containers/Page.jsx
@@ -84,9 +84,10 @@ class Page extends Component {
   }
 
   static getDerivedStateFromProps = (props, state) => {
-    if (props.location.pathname !== '/u/my-activities') {
+    const { location, showModal } = props;
+    if (location.pathname !== '/u/my-activities') {
       return ({
-        showModal: props.showModal,
+        showModal,
       });
     }
     return state;

--- a/src/containers/forms/CommentsForm.jsx
+++ b/src/containers/forms/CommentsForm.jsx
@@ -22,6 +22,9 @@ import pointsToDollarConverter from '../../../src/helpers/pointsToDollarsConvert
 // fixtures
 import { moreInfoText, rejectionText } from '../../fixtures/commentsFormText';
 
+// constants
+import SNACKBARTIMEOUT from '../../constants/snackbarTimeout';
+
 class CommentsForm extends Component {
   static defaultProps = {
     message: {
@@ -73,7 +76,7 @@ class CommentsForm extends Component {
   componentDidUpdate(prevProps) {
     const { message } = this.props;
     if (prevProps.message.type !== message.type && message.type === 'success') {
-      setTimeout(() => this.handleCloseModal(), 3100);
+      setTimeout(() => this.handleCloseModal(), SNACKBARTIMEOUT);
     }
   }
 

--- a/src/containers/forms/RedeemPointsForm.jsx
+++ b/src/containers/forms/RedeemPointsForm.jsx
@@ -22,6 +22,9 @@ import pointsToDollarConverter from '../../helpers/pointsToDollarsConverter';
 // fixtures
 import centers from '../../fixtures/centers';
 
+// constants
+import SNACKBARTIMEOUT from '../../constants/snackbarTimeout';
+
 class RedeemPointsForm extends Component {
   static defaultProps = {
     message: {},
@@ -86,10 +89,8 @@ class RedeemPointsForm extends Component {
    */
   componentDidUpdate(prevProps) {
     const { type } = this.props.message;
-    if (type !== prevProps.message.type) {
-      if (type === 'success') {
-        setTimeout(() => { this.handleCloseModal(); }, 2000);
-      }
+    if (type !== prevProps.message.type && type === 'success') {
+      setTimeout(() => { this.handleCloseModal(); }, SNACKBARTIMEOUT);
     }
   }
 

--- a/tests/actions/verifyActivityActions.test.js
+++ b/tests/actions/verifyActivityActions.test.js
@@ -127,7 +127,7 @@ describe('Verify Activity Actions', () => {
       },
     ];
 
-    moxios.stubRequest(`${config.API_BASE_URL}/logged-activities/approve/`, {
+    moxios.stubRequest(`${config.API_BASE_URL}/approve/logged-activities/`, {
       status: 200,
       response: { data: approvedActivities },
     });
@@ -149,7 +149,7 @@ describe('Verify Activity Actions', () => {
       },
     ];
 
-    moxios.stubRequest(`${config.API_BASE_URL}/logged-activities/approve/`, {
+    moxios.stubRequest(`${config.API_BASE_URL}/approve/logged-activities/`, {
       status: 400,
     });
 


### PR DESCRIPTION
##### What does this PR do?
On successful creation of a redemption, the redeem points modal shows a message i.e. success or error message, before closing the modal.
##### Description of Task to be completed?
Add the timeout used to call the `handleCloseModal ` function
##### What are the relevant Pivotal Tracker stories?
[159517835](https://www.pivotaltracker.com/story/show/159517835)
