### PR TITLE
Display name for stats on redemption page according to filtered redemptions status

### DIFF
--- a/src/containers/Redemptions.jsx
+++ b/src/containers/Redemptions.jsx
@@ -119,6 +119,7 @@ class Redemptions extends React.Component {
       showTabs: false,
       showModal: false,
       statuses: [ALL, PENDING, REJECTED, APPROVED],
+      statsRedemptionStatus: 'Pending Redemptions',
     };
   }
 
@@ -181,10 +182,12 @@ class Redemptions extends React.Component {
     filterResult = filterActivitiesByStatus(societyRedemptions, filterStatus);
     if (filterStatus === ALL) {
       filterResult = societyRedemptions;
+      this.setState(() => ({ statsRedemptionStatus: `${status} Redemptions` }));
     }
     this.setState({
       filteredActivities: filterResult,
       selectedStatus: status,
+      statsRedemptionStatus: `${status} Redemptions`,
     });
   }
 
@@ -364,8 +367,8 @@ class Redemptions extends React.Component {
       selectedRedemption,
       statuses,
       showModal,
+      statsRedemptionStatus,
     } = this.state;
-
     return (
       <Page
         selectedItem={selectedRedemption}
@@ -393,7 +396,7 @@ class Redemptions extends React.Component {
         </div>
         <aside className='sideContent'>
           <Stats
-            stats={statsGenerator(filteredActivities, 'Pending redemptions', 'Total points')}
+            stats={statsGenerator(filteredActivities, statsRedemptionStatus, 'Total points')}
           />
         </aside>
       </Page>


### PR DESCRIPTION
##### What does this PR do?
Displays name for stats on redemption page according to filtered redemptions status.

##### Description of Task to be completed?
As a society president, success OPS or CIO when I am on the redemptions page and I filter redemptions. 
The stats title should tally with the filtered redemption status.


##### What are the relevant Pivotal Tracker stories?
[159518152](https://www.pivotaltracker.com/story/show/159518152)

#### Any background context you want to provide?
![screen shot 2018-08-13 at 12 36 25 pm](https://user-images.githubusercontent.com/26232631/44029833-aa22a126-9ef6-11e8-9206-b77bfb458f45.png)

![screen shot 2018-08-13 at 12 36 32 pm](https://user-images.githubusercontent.com/26232631/44029889-e9b41f68-9ef6-11e8-833b-9c3a938b2020.png)
![screen shot 2018-08-13 at 12 36 41 pm](https://user-images.githubusercontent.com/26232631/44029905-f95a9938-9ef6-11e8-8cd3-a928a3dd51fe.png)

