### PR TITLE
#159695959  Fix display of activity description, date of logged activity and user profile details.

### DIFF
--- a/src/assets/scss/ProfileDisplay.scss
+++ b/src/assets/scss/ProfileDisplay.scss
@@ -1,6 +1,9 @@
+@import '../../assets/scss/_vars'; 
+
 .profileDisplay {
   position: relative;
   padding: 0 2.4rem;
+  color: $black;
 }
 
 .profileDisplay__name {

--- a/src/containers/Society.jsx
+++ b/src/containers/Society.jsx
@@ -40,7 +40,6 @@ class Society extends Component {
   static getDerivedStateFromProps(nextProps) {
     const { loggedActivities } = nextProps.societyInfo.info;
     return {
-      allActivities: loggedActivities,
       filteredActivities: loggedActivities,
       ...nextProps.societyInfo.info,
     };
@@ -53,7 +52,6 @@ class Society extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      allActivities: [],
       filteredActivities: [],
       selectedStatus: 'All',
       initialStatus: 'All',
@@ -109,8 +107,8 @@ class Society extends Component {
                         <ActivityCard
                           id={activity.id}
                           category={activity.category}
-                          date={dateFormatter(activity.date)}
-                          description={activity.activity}
+                          date={dateFormatter(activity.activityDate)}
+                          description={activity.description}
                           points={activity.points}
                           status={activity.status}
                           showUserDetails={showUserDetails}


### PR DESCRIPTION
 ##### What does this PR do?
Fixes bugs to have activity cards display description and date which the activity was logged. Also,  make the details of logged in user, visible under the profile section in society pages.


##### Description of Task to be completed?
Passed down `activityDate` and `description` prop to ActivityCards component.
Add `color` property to `.profileDisplay` class.

##### What are the relevant Pivotal Tracker stories?
[159695959](https://www.pivotaltracker.com/story/show/159695959)

##### Screenshots
![screen shot 2018-08-14 at 10 14 15 am 2](https://user-images.githubusercontent.com/29278184/44077013-ed18ffac-9faa-11e8-9d81-5011a4c49d2f.png)

