### PR TITLE
Display activities logged on VerifyActivities page for verification.

### DIFF
--- a/src/actions/allActivitiesActions.js
+++ b/src/actions/allActivitiesActions.js
@@ -48,7 +48,7 @@ export const fetchAllActivitiesFailure = error => (
 export const fetchAllActivities = () => (
   (dispatch) => {
     dispatch(fetchAllActivitiesRequests());
-    return axios.get(`${config.API_BASE_URL}/logged-activities`)
+    return axios.get(`${config.API_BASE_URL}/logged-activities?paginate=false`)
       .then((response) => {
         dispatch(fetchAllActivitiesSuccess(response.data.data.loggedActivities));
       })

--- a/src/containers/MyActivities.jsx
+++ b/src/containers/MyActivities.jsx
@@ -171,18 +171,26 @@ class MyActivities extends Component {
                 !requesting &&
                   <MasonryLayout
                     items={
-                      filteredActivities.map(activity => (
-                        <ActivityCard
-                          id={activity.id}
-                          category={activity.category}
-                          date={dateFormatter(activity.date)}
-                          description={activity.description || activity.activity}
-                          points={activity.points}
-                          status={activity.status}
+                      filteredActivities.map((activity) => {
+                        const {
+                          id,
+                          category,
+                          activityDate,
+                          description,
+                          points,
+                          status,
+                        } = activity;
+                        return (<ActivityCard
+                          id={id}
+                          category={category}
+                          date={dateFormatter(activityDate)}
+                          description={description}
+                          points={points}
+                          status={status}
                           userCanEdit={userCanEdit}
                           handleClick={this.handleClick}
-                        />
-                      ))
+                        />);
+                      })
                     }
                   />
               }

--- a/src/containers/VerifyActivities.jsx
+++ b/src/containers/VerifyActivities.jsx
@@ -163,8 +163,9 @@ class VerifyActivities extends Component {
       break;
     }
     default:
-      break;
+      return null;
     }
+    return null;
   }
 
   /**
@@ -256,7 +257,7 @@ class VerifyActivities extends Component {
               const {
                 id,
                 category,
-                date,
+                activityDate,
                 description,
                 points,
                 status,
@@ -264,7 +265,7 @@ class VerifyActivities extends Component {
               return (<ActivityCard
                 id={id}
                 category={category}
-                date={dateFormatter(date)}
+                date={dateFormatter(activityDate)}
                 description={description || 'There is no description for this activity'}
                 points={points}
                 status={status}
@@ -291,7 +292,7 @@ class VerifyActivities extends Component {
             const {
               id,
               category,
-              date,
+              activityDate,
               description,
               points,
               status,
@@ -299,7 +300,7 @@ class VerifyActivities extends Component {
             return (<ActivityCard
               id={id}
               category={category}
-              date={dateFormatter(date)}
+              date={dateFormatter(activityDate)}
               description={description || 'There is no description for this activity'}
               points={points}
               status={status}

--- a/tests/actions/allActivitiesActions.test.js
+++ b/tests/actions/allActivitiesActions.test.js
@@ -36,7 +36,7 @@ describe('All Activities Actions', () => {
   });
 
   it('should dispatch FETCH_ALL_ACTIVITIES_SUCCESS on successfull fetching of activities', async () => {
-    moxios.stubRequest(`${config.API_BASE_URL}/logged-activities`, {
+    moxios.stubRequest(`${config.API_BASE_URL}/logged-activities?paginate=false`, {
       status: 200,
       response: {
         data: {
@@ -50,7 +50,7 @@ describe('All Activities Actions', () => {
   });
 
   it('should dispatch FETCH_ALL_ACTIVITIES_FAILURE on unsuccessfull fetching of activities', async () => {
-    moxios.stubRequest(`${config.API_BASE_URL}/logged-activities`, { status: 400 });
+    moxios.stubRequest(`${config.API_BASE_URL}/logged-activities?paginate=false`, { status: 400 });
     const expectedFailAction = {
       type: FETCH_ALL_ACTIVITIES_FAILURE,
       error: new Error('Request failed with status code 400', 400),

--- a/tests/containers/MyActivities.test.jsx
+++ b/tests/containers/MyActivities.test.jsx
@@ -36,11 +36,15 @@ const mounted = mount.bind(
 
 const setUpWrapper = ({
   requesting = false,
+  categories = [],
 } = {}) => {
   const props = {
+    activities,
+    categories,
     requesting,
     history,
     fetchUserInfo,
+    fetchCategories,
     changePageTitle,
     fetchMyActivities,
   };
@@ -83,10 +87,13 @@ describe('<MyActivities />', () => {
     expect(shallowWrapper.find('MasonryLayout').length).toBe(1);
   });
 
-  it('should render ActivityCards', () => {
+  it('should change state of allActivities', () => {
     const mountedWrapper = mounted();
     mountedWrapper.setState({ allActivities: activities, filteredActivities: activities, requesting: false });
     expect(mountedWrapper.state().allActivities).toEqual(activities);
+  });
+  it('should render ErrorMessage component when activities are not passed down as props', () => {
+    expect(shallowWrapper.find('MasonryLayout').dive().find('ErrorMessage').length).toBe(1);
   });
 
   it('should filter activity given status', () => {

--- a/tests/containers/VerifyActivities.test.jsx
+++ b/tests/containers/VerifyActivities.test.jsx
@@ -9,6 +9,7 @@ import VerifyActivities from '../../src/containers/VerifyActivities';
 import storeFixture from '../../src/fixtures/store';
 import society from '../../src/fixtures/society';
 import activity from '../../src/fixtures/activity';
+import activities from '../../src/fixtures/activities';
 
 const store = createMockStore(storeFixture);
 const history = { push: () => { }, location: { pathname: '' } };
@@ -23,6 +24,8 @@ describe('<VerifyActivities />', () => {
     fetchUserInfo: () => { },
     changePageTitle: () => { },
     fetchSocietyInfo: () => { },
+    societyName: 'iStelle',
+    allActivities: activities,
     societyActivities: society.loggedActivities,
     requesting: false,
     verifyActivitiesOps: verifyActivitiesOpsSpy,
@@ -72,6 +75,15 @@ describe('<VerifyActivities />', () => {
     expect(component.find('MasonryLayout').length).toBe(1);
   });
 
+  it('should render ErrorMessage component when activities are not passed down as props', () => {
+    expect(component.find('MasonryLayout').dive().find('ErrorMessage').length).toBe(1);
+  });
+
+  it('should render Activity cards', () => {
+    component.setState({ filteredActivities: activities });
+    expect(component.find('MasonryLayout').dive().find('ActivityCard').length).toBe(4);
+  });
+
   it('should have the <LinearLayout /> layout when role is successOps', () => {
     component.setProps({ userRoles: ['success ops'] });
     expect(component.find('LinearLayout').length).toBe(1);
@@ -114,6 +126,12 @@ describe('<VerifyActivities />', () => {
     const instance = component.instance();
     instance.handleClick('moreInfo', '8437fa68-8e6b-11e8-a05c-9801a7ae0330');
     expect(component.state().showModal).toBeTruthy();
+  });
+
+  it('should return null the default case when handleClick is invoked with no click action', () => {
+    const instance = component.instance();
+    const result = instance.handleClick();
+    expect(result).toBeNull();
   });
 
   it('should change state of selectedActivity to {} when deselectActivity is invoked ', () => {


### PR DESCRIPTION
##### What does this PR do?
Displays activities logged for a specific society on VerifyActivities page for verification by society secretary.

##### Description of Task to be completed?
Below are steps taken to have logged activities displayed on VerifyActivities page
* change URL in `fetchAllActivities` thunk to `/logged-activities?paginate=false`
* change date prop in ActivityCard to `activityDate`

##### What are the relevant Pivotal Tracker stories?
[#159763170](https://www.pivotaltracker.com/story/show/159763170)

##### Screenshots?
![screen shot 2018-08-15 at 11 48 05 am 2](https://user-images.githubusercontent.com/29278184/44140230-2339f406-a082-11e8-86cd-9ab1ecf77e3d.png)
