### PR TITLE
Fix DatePicker, SnackBar Duration, Null description error

### DIFF
--- a/src/common/DateField.jsx
+++ b/src/common/DateField.jsx
@@ -2,14 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
+import DEFAULT_DATE_FORMAT from '../constants/dataFormats';
+
 /**
 * @name DateField
 * @summary Returns html 5 datefield
 * @returns Returns html 5 datefield
 */
 const DateField = ({ handleChange, value }) => {
-  const today = moment().format('YYYY-MM-DD');
-  const startOfMonth = moment().startOf('month').format('YYYY-MM-DD');
+  const today = moment().format(DEFAULT_DATE_FORMAT);
+  const minDate = moment().subtract(30, 'days').format(DEFAULT_DATE_FORMAT);
   return (
     <div className='formField'>
       <span className='formField__label'>Date</span>
@@ -20,7 +22,7 @@ const DateField = ({ handleChange, value }) => {
         onChange={handleChange}
         value={value}
         max={today}
-        min={startOfMonth}
+        min={minDate}
       />
     </div>
   );

--- a/src/components/activities/ActivityCard.jsx
+++ b/src/components/activities/ActivityCard.jsx
@@ -285,6 +285,10 @@ class ActivityCard extends Component {
       (status === STATUSES[2] || status === STATUSES[1]) && userCanEdit
         ? 'activity__right--editable'
         : ''}`;
+    const descriptionHtml = description ?
+      <TruncateDescription description={description} wordCount={wordCount} />
+      : '';
+
     return (
       <div className='activity'>
         {this.renderUserDetails()}
@@ -310,7 +314,7 @@ class ActivityCard extends Component {
             {page === '/u/verify-activities' && this.renderCheckbox()}
           </div>
           <div className='activity__content'>
-            <TruncateDescription description={description} wordCount={wordCount} />
+            { descriptionHtml }
           </div>
         </div>
         <div className='activity__footer'>

--- a/src/components/notifications/SnackBar.jsx
+++ b/src/components/notifications/SnackBar.jsx
@@ -4,7 +4,7 @@ import CloseIcon from '../svgIcons/notificationIcons/Close';
 import ErrorIcon from '../svgIcons/notificationIcons/Error';
 
 // Constants
-import SNACKBARTIMEOUT from '../../constants/snackbarTimeout';
+import { SNACKBARTIMEOUT_SUCCESS } from '../../constants/snackbarTimeout';
 
 class SnackBar extends Component {
   /**
@@ -63,7 +63,7 @@ class SnackBar extends Component {
   showClass = () => {
     const { message } = this.state;
     if (message.type === 'success') {
-      setTimeout(() => { this.setState({ show: false }); }, SNACKBARTIMEOUT);
+      setTimeout(() => { this.setState({ show: false }); }, SNACKBARTIMEOUT_SUCCESS);
     }
 
     return message ? `snackbar snackbar--show ${message.type}` : '';

--- a/src/constants/dataFormats.js
+++ b/src/constants/dataFormats.js
@@ -1,0 +1,3 @@
+const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD';
+
+export default DEFAULT_DATE_FORMAT;

--- a/src/constants/snackbarTimeout.js
+++ b/src/constants/snackbarTimeout.js
@@ -1,3 +1,3 @@
-const SNACKBARTIMEOUT = 3000;
+export const SNACKBARTIMEOUT = 3000;
 
-export default SNACKBARTIMEOUT;
+export const SNACKBARTIMEOUT_SUCCESS = 500;

--- a/tests/common/DateField.test.jsx
+++ b/tests/common/DateField.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import DateField from '../../src/common/DateField';
+
+describe('<DateField />', () => {
+  const props = {
+    handleChange: () => {},
+    value: '2018-08-17',
+  };
+
+  it('should render withour crashing', () => {
+    expect(mount.bind(null, <DateField {...props} />)).not.toThrow();
+  });
+});


### PR DESCRIPTION
### What does this PR do?
* Adjust validity period on Date picker for activity to be logged
* Update the SnackBar timeout Duration to 500ms
* Fix TruncateDescription in ActivityCard

### Description of Task to be completed?
* Logging of activities should be possible for activities that happened up to 30 days ago. They are currently set to just the beginning of the month at the time of the logging. This PR adjusts the DatePicker valid window for up to a month back
* The SnackBar duration on success is changed from a full 3 seconds! to a manageable half a second
* The TruncateDescription module is only called if the description _is not null_

### Any background context you want to provide?
We are using moments to adjust this.
The native date input field doesn't support opening the caret when the input field is clicked. The alternative is to build a custom date picker which isn't a priority for now. We are sticking with the current one.

### What are the relevant Pivotal Tracker stories?
N/A

### Screenshots?

Empty Description
<img width="1440" alt="screen shot 2018-08-17 at 11 59 13" src="https://user-images.githubusercontent.com/6057761/44257603-2f841b80-a215-11e8-83f1-e649d3466a5c.png">


Date picker validity period
<img width="1440" alt="screen shot 2018-08-17 at 11 59 38" src="https://user-images.githubusercontent.com/6057761/44257967-53942c80-a216-11e8-82ee-f4cb8212757a.png">


