### PR TITLE
Add support for Multiple Participants

### DIFF
--- a/src/assets/scss/FormField.scss
+++ b/src/assets/scss/FormField.scss
@@ -1,3 +1,5 @@
+@import '../../assets/scss/_vars';
+
 .formField {
   display: flex;
   align-items: center;
@@ -20,6 +22,72 @@
   &--text-display {
     margin-top: 0;
     padding-bottom: .7rem;
+  }
+
+  &--checkbox {
+    margin-top: 0;
+    width:25%;
+    padding-right: 3rem;
+    text-align: right;
+  }
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 6.0rem;
+  height: 3.4rem;
+
+  & input {
+    display: none;
+  
+    &:checked {
+    
+      + .slider {
+        background-color: $andelaBlue;
+      }
+    
+      + .slider:before {
+        -webkit-transform: translateX(2.6rem);
+        transform: translateX(2.6rem);
+      }
+    }
+  }
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 .1rem $andelaBlue;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #eee;
+  -webkit-transition: .3s;
+  transition: .3s;
+
+  &:before {
+    position: absolute;
+    content: "";
+    height: 2.6rem;
+    width: 2.6rem;
+    left: .4rem;
+    bottom: .4rem;
+    background-color: $lightAccent;
+    -webkit-transition: .3s;
+    transition: .3s;
+  }
+
+  &.round {
+    border-radius: 34px;
+  }
+
+  &.round:before {
+    border-radius: 50%;
   }
 }
 

--- a/src/containers/forms/CreateCategoryForm.jsx
+++ b/src/containers/forms/CreateCategoryForm.jsx
@@ -48,6 +48,7 @@ class CreateCategoryForm extends Component {
     this.state = {
       value: '',
       name: '',
+      supportsMultiple: false,
       description: '',
       errors: {},
     };
@@ -66,6 +67,17 @@ class CreateCategoryForm extends Component {
   }
 
   /**
+   * @name handleCheck
+   * @summary toggles state when checkbox is clicked
+   * @returns {void}
+   */
+  handleCheck = () => {
+    this.setState({
+      supportsMultiple: !this.state.supportsMultiple,
+    });
+  }
+
+  /**
    * @memberOf CreateCategoryForm
    * change event handler
    * @param {Event} event - change event on select input
@@ -80,6 +92,7 @@ class CreateCategoryForm extends Component {
   handleAddEvent = () => {
     const {
       name,
+      supportsMultiple,
       description,
       value,
     } = this.state;
@@ -92,6 +105,7 @@ class CreateCategoryForm extends Component {
       errors: validateFormFields(category),
     }, () => {
       if (Object.keys(this.state.errors).length === 0) {
+        category.supports_multiple = supportsMultiple;
         this.props.createCategory(category);
       }
     });
@@ -105,6 +119,7 @@ class CreateCategoryForm extends Component {
     this.setState({
       name: '',
       value: '',
+      supportsMultiple: false,
       description: '',
       errors: {},
     });
@@ -151,6 +166,21 @@ class CreateCategoryForm extends Component {
         <span className='validate__errors'>
           {this.renderValidationError('value')}
         </span>
+        <div className='formField'>
+          { /* eslint-disable */ }
+          <label className='formField__label--checkbox'>Supports Multiple</label>
+          { /* eslint-disable */ }
+          <label className="switch">
+            <input
+              type='checkbox'
+              name='supportsMultiple'
+              className='create-category-checkbox'
+              checked={this.state.supportsMultiple}
+              onChange={this.handleCheck}
+            />
+            <span className="slider round"></span>
+          </label>
+        </div>
         <FormError errors={this.state.errors} fieldName='points' />
         <TextArea
           title='Description'

--- a/tests/containers/forms/CreateCategoryForm.test.jsx
+++ b/tests/containers/forms/CreateCategoryForm.test.jsx
@@ -15,8 +15,14 @@ const infoMessage = {
 const defaultState = {
   name: '',
   value: '',
+  supportsMultiple: false,
   description: '',
   errors: {},
+};
+
+const baseProps = {
+  closeModal: () => {},
+  createCategory: jest.fn(),
 };
 
 describe('<CreateCategoryForm />', () => {
@@ -24,12 +30,10 @@ describe('<CreateCategoryForm />', () => {
   let mounted;
   beforeEach((() => {
     wrapper = shallow(<CreateCategoryForm.WrappedComponent
-      closeModal={() => { }}
-      createCategory={() => { }}
+      {...baseProps}
     />);
     mounted = mount(<CreateCategoryForm.WrappedComponent
-      closeModal={() => { }}
-      createCategory={() => { }}
+      {...baseProps}
     />);
   }));
 
@@ -96,5 +100,27 @@ describe('<CreateCategoryForm />', () => {
     jest.spyOn(instance, 'renderValidationError');
     instance.handleAddEvent();
     expect(instance.renderValidationError).toHaveBeenCalled();
+  });
+
+
+  it('should change state when the checkbox is clicked', () => {
+    wrapper.setState({ supportsMultiple: true });
+    const checkbox = wrapper.find('.create-category-checkbox');
+    checkbox.simulate('change');
+    expect(wrapper.state().supportsMultiple).toBe(false);
+  });
+
+  it('should run createCategory when handleAddEvent is called', () => {
+    const instance = wrapper.instance();
+    jest.spyOn(instance, 'handleAddEvent');
+    instance.setState({
+      name: 'Test Category',
+      value: '34',
+      description: 'Lorem Ipsum',
+      supportsMultiple: true,
+    }, () => {
+      instance.handleAddEvent();
+    });
+    expect(baseProps.createCategory).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
##### What does this PR do?
Adds option to specify categories that support multiple participants

##### Description of Task to be completed?
Introduces form field in create category modal to allow Success Ops member to specify support for multiple participants. This value is registered as a boolean value.

##### What are the relevant Pivotal Tracker stories?
[159956751](https://www.pivotaltracker.com/n/projects/2154966/stories/159956751)

##### Screenshots?
<img width="1440" alt="screen shot 2018-08-24 at 12 43 50" src="https://user-images.githubusercontent.com/6057761/44578109-73d66500-a79b-11e8-8080-8b48d4f41c02.png">

