### PR TITLE
Fix bug to filter redemptions by completed status when role is finance

### DIFF
--- a/src/containers/Redemptions.jsx
+++ b/src/containers/Redemptions.jsx
@@ -24,7 +24,7 @@ import filterActivitiesByStatus from '../helpers/filterActivitiesByStatus';
 
 // constants
 import { VERIFICATION_USERS, SUCCESS_OPS, CIO, SOCIETY_PRESIDENT, STAFF_USERS, FINANCE } from '../constants/roles';
-import { ALL, APPROVED, PENDING, REJECTED } from '../constants/statuses';
+import { ALL, APPROVED, PENDING, REJECTED, COMPLETED } from '../constants/statuses';
 import clickActions from '../constants/clickAction';
 
 // fixtures
@@ -89,10 +89,15 @@ class Redemptions extends React.Component {
       } = state;
 
       // state values for cio/success ops role
-      if (hasAllowedRole(userRoles, [CIO, SUCCESS_OPS, FINANCE])) {
+      if (hasAllowedRole(userRoles, [CIO, SUCCESS_OPS])) {
         showTabs = true;
         selectedStatus = PENDING;
         preSelectedRemptions = filterActivitiesByStatus(redemptions, PENDING)
+          .filter(redemption => redemption.society.name.toLowerCase() === selectedSociety.toLowerCase());
+      } else if (hasAllowedRole(userRoles, [FINANCE])) {
+        showTabs = true;
+        selectedStatus = COMPLETED;
+        preSelectedRemptions = filterActivitiesByStatus(redemptions, COMPLETED)
           .filter(redemption => redemption.society.name.toLowerCase() === selectedSociety.toLowerCase());
       } else {
         preSelectedRemptions = redemptions
@@ -209,12 +214,21 @@ class Redemptions extends React.Component {
    */
   handleChangeTab = (event, title) => {
     event.preventDefault();
-    const pendingRedemptions = filterActivitiesByStatus(this.props.redemptions, PENDING)
-      .filter(red => red.society.name.toLowerCase() === title.toLowerCase());
+    const { userRoles, redemptions } = this.props;
+    let selectedStatus;
+    let societyRedemptions;
+    societyRedemptions = redemptions.filter(red => red.society.name.toLowerCase() === title.toLowerCase());
+    if (hasAllowedRole(userRoles, [FINANCE])) {
+      selectedStatus = COMPLETED;
+      societyRedemptions = filterActivitiesByStatus(societyRedemptions, COMPLETED);
+    } else {
+      selectedStatus = PENDING;
+      societyRedemptions = filterActivitiesByStatus(societyRedemptions, PENDING);
+    }
     this.setState({
-      filteredActivities: pendingRedemptions,
+      filteredActivities: societyRedemptions,
       selectedSociety: title.toLowerCase(),
-      selectedStatus: 'pending',
+      selectedStatus,
     });
   }
 

--- a/tests/containers/Redemptions.test.jsx
+++ b/tests/containers/Redemptions.test.jsx
@@ -147,6 +147,14 @@ describe('<Redemptions />', () => {
     expect(instance.state.filteredActivities.length).toBe(1);
   });
 
+  it('should update state of filteredActivities when role is Finance', () => {
+    const { shallowWrapper } = setUpWrapper({ roles: { 'finance': 'Kabc' } });
+    const instance = shallowWrapper.instance();
+    instance.handleChangeTab(event, 'phoenix');
+    expect(instance.state.selectedSociety).toBe('phoenix');
+    expect(instance.state.filteredActivities.length).toBe(0);
+  });
+
   it('should call verifyRedemption thunk when redemption is approved', () => {
     const { shallowWrapper } = setUpWrapper();
     const instance = shallowWrapper.instance();


### PR DESCRIPTION
##### What does this PR do?
Displays redemptions with the status of `completed`

##### Description of Task to be completed?
* Add a check for the role of `finance`
* Filter redemptions by status `completed` 
* Set selected status to be `completed`
* Modified filter in `handleChangeTab ` to check the role of finance and then filter by completed status

##### What are the relevant Pivotal Tracker stories?
[160583562](https://www.pivotaltracker.com/story/show/160583562)
