### PR TITLE
[160618987] Remove SUCCESS_OPS rights to redemption view

### DIFF
--- a/src/helpers/pageInfo.js
+++ b/src/helpers/pageInfo.js
@@ -49,7 +49,7 @@ const pageInfo = {
       url: '/u/redemptions',
       component: Redemptions,
       menuIcon: RedemptionsIcon,
-      allowedRoles: [SUCCESS_OPS, SOCIETY_PRESIDENT, CIO, FINANCE],
+      allowedRoles: [SOCIETY_PRESIDENT, CIO, FINANCE],
     },
     {
       title: 'Categories',

--- a/tests/actions/createCategoryActions.test.js
+++ b/tests/actions/createCategoryActions.test.js
@@ -84,4 +84,35 @@ describe('Create Category Actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it('dispatches CREATE_CATEGORY_FAILURE when creating the category fails', () => {
+    store = mockStore({ categories });
+
+    const expectedActions = [
+      {
+        type: CREATE_CATEGORY_REQUEST,
+      },
+      {
+        type: CREATE_CATEGORY_FAILURE,
+        error: new Error('Request failed with status code 400'),
+      },
+    ];
+
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        status: 400,
+      }).then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+    });
+
+    moxios.stubRequest(`${config.API_BASE_URL}/activity-types/`, {
+      status: 400,
+    });
+
+    return store.dispatch(createCategory(categories[0])).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
 });


### PR DESCRIPTION
##### What does this PR do?
Disable **SUCCESS_OPS** role from accessing the Redemptions Page

##### Description of Task to be completed?
Remove **SUCCESS_OPS** role from redemption page's listed roles

##### Any background context you want to provide?
**SUCCESS_OPS** does not have any role in the redemption user flow

##### What are the relevant Pivotal Tracker stories?
[160618987](https://www.pivotaltracker.com/story/show/160618987)

##### Questions?
N/A
##### Screenshots?
N/A