### PR TITLE
#161249824 Remove modal button from Society view

### DIFF
--- a/src/containers/Page.jsx
+++ b/src/containers/Page.jsx
@@ -163,8 +163,10 @@ class Page extends Component {
     if (location.pathname === '/u/categories' && hasAllowedRole(userRoles, SUCCESS_OPS)) {
       FAB = <FloatingButton onClick={this.onFabClick} />;
     } else if (showModal ||
-      hasAllowedRole(userRoles, STAFF_USERS
-      || !userRoles.length) || location.pathname === '/u/verify-activities') {
+        hasAllowedRole(userRoles, STAFF_USERS)
+        || !userRoles.length
+        || location.pathname === '/u/verify-activities'
+        || location.pathname.match(/\/society\/[a-z]+/)) {
       FAB = '';
     } else {
       FAB = <FloatingButton onClick={this.onFabClick} />;


### PR DESCRIPTION
##### What does this PR do?
Removes the modal button from the Society View.
##### Description of Task to be completed?
- Add a regex to prevent all Society urls (/society/...) from having the modal button rendered on them.
##### Screenshots?
## Before
![before](https://user-images.githubusercontent.com/30657749/47153527-95118880-d2e8-11e8-999c-e5ae9873b7e2.png)
## After
<img width="809" alt="after" src="https://user-images.githubusercontent.com/30657749/47153538-9ba00000-d2e8-11e8-948c-353a93ce88e0.png">
