### PR TITLE
#160618987 Remove SUCCESS OPS rights to Redemptions View

### DIFF
--- a/src/assets/scss/Header.scss
+++ b/src/assets/scss/Header.scss
@@ -16,13 +16,13 @@
   height: 100%;
   border-radius: 50%;
   cursor: pointer;
+  outline: none;
 }
 
 .headerIcon__image--photo {
   background-color: #eee;
   background-size: cover;
   background-repeat: no-repeat;
-
 }
 
 .headerIcon__image svg {

--- a/src/helpers/pageInfo.js
+++ b/src/helpers/pageInfo.js
@@ -49,7 +49,7 @@ const pageInfo = {
       url: '/u/redemptions',
       component: Redemptions,
       menuIcon: RedemptionsIcon,
-      allowedRoles: [SUCCESS_OPS, SOCIETY_PRESIDENT, CIO, FINANCE],
+      allowedRoles: [SOCIETY_PRESIDENT, CIO, FINANCE],
     },
     {
       title: 'Categories',


### PR DESCRIPTION
#### What does this PR do?
It prevents the success-ops user from having access to the redemptions view.

#### Description of Task to be completed?
Remove the `Success-ops` role for redemptions in the `PageInfo` object.

#### Screenshots?
##### Before
![image](https://user-images.githubusercontent.com/23665997/47185971-f35d5c00-d326-11e8-9214-13c65c327871.png)

##### After
![image](https://user-images.githubusercontent.com/23665997/47186000-08d28600-d327-11e8-9d97-6303799308e6.png)

