### PR TITLE
 Creation of a 404 page for invalid routes.

### DIFF
--- a/src/assets/scss/_pageNotFound.scss
+++ b/src/assets/scss/_pageNotFound.scss
@@ -1,0 +1,34 @@
+.not-found {
+    display: flex;
+    flex-direction: column;
+    height: auto;
+    align-items: center;
+    margin-top: 17%;
+}
+
+.not-found__code{
+    display: flex;
+    flex-direction: row;
+}
+
+.not-found__text {
+    font-size: 15px;
+    color: $disableButton;
+}
+
+.not-found__text .home-404 {
+    text-decoration: none;
+    color: $andelaBlue;
+}
+
+.not-found__code {
+  font-size: 150px;
+}
+
+.not-found__code .not-found__zero {
+    color: $andelaBlue;
+}
+
+.not-found__code .not-found__four {
+    color: $black;
+}

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -31,3 +31,4 @@
 @import 'Loader';
 @import 'CategoryCard';
 @import 'Categories';
+@import 'pageNotFound';

--- a/src/containers/PageNotFound.jsx
+++ b/src/containers/PageNotFound.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const pageNotFound = () => (
+  <div className='not-found'>
+    <div className='not-found__code'>
+      <div className='not-found__four'>4</div>
+      <div className='not-found__zero'>0</div>
+      <div className='not-found__four'>4</div>
+    </div>
+    <div className='not-found__text'>
+      <article>
+        The page you are trying to access does not exist. However you can go back
+        <Link to='/' className='home-404'> home</Link>.
+      </article>
+    </div>
+  </div>
+);
+
+export default pageNotFound;

--- a/src/containers/Router.jsx
+++ b/src/containers/Router.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import Signin from '../containers/SignIn';
 import pageInfo from '../helpers/pageInfo';
 import PrivateRoute from '../components/routes/PrivateRoute';
+import PageNotFound from './PageNotFound';
 
 /**
  * @name Router
@@ -38,6 +39,7 @@ const Router = ({ profile }) => (
             />
         ))
       }
+      <Route path='*' component={PageNotFound} />
     </Switch>
   </BrowserRouter>);
 

--- a/tests/containers/PageNotFound.test.jsx
+++ b/tests/containers/PageNotFound.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import PageNotFound from '../../src/containers/PageNotFound';
+
+describe('<PageNotFound />', () => {
+  let shallowWrapper;
+  beforeEach((() => {
+    shallowWrapper = shallow(<PageNotFound />);
+  }));
+
+  it('should render without crashing', () => {
+    expect(shallowWrapper).toHaveLength(1);
+  });
+
+  it('should contain an article tag', () => {
+    const instance = shallowWrapper.instance();
+    expect(shallowWrapper.find('article').length).toBe(1);
+    expect(instance).toBe(null);
+    expect(shallowWrapper.find('article').children().length).toBe(3);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
It directs users to a 404 page when they try to or mistakenly access invalid routes.

#### Description of Task to be completed?
- Created a `PageNotFound` component for the feature and styled it appropriately.
- All invalid routes redirect to the `PageNotFound` component.

#### Screenshots?
![image](https://user-images.githubusercontent.com/23665997/47558098-36609600-d90a-11e8-8381-3c9570375b7f.png)

##### What are the relevant Pivotal Tracker stories?
`#61482151`

