### PR TITLE
#161539722 Send customised notifications for develop and master builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}
           - v1-dependencies-
-
+          
       - run: yarn install
 
       - save_cache:
@@ -52,7 +52,22 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       - run:
           name: Build and release application
-          command: chmod +x scripts/deploy.sh && scripts/deploy.sh
+          command: |
+            chmod +x scripts/deploy.sh && scripts/deploy.sh
+      - run:
+          name: Build Success
+          when: on_success
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+                bash scripts/slack_notification.sh "success"
+            fi
+      - run:
+          name: Build Failed
+          when: on_fail
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+                bash scripts/slack_notification.sh "fail"
+            fi
 
 workflows:
   version: 2

--- a/scripts/slack_notification.sh
+++ b/scripts/slack_notification.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+
+declare_env_variables() {
+
+  # Declaring environment variables
+  #
+  # Some environment variables assigned externally are:
+  # SLACK_CHANNEL_HOOK : This is the webhook for the Slack App where notifications will be sent from
+  # DEPLOYMENT_CHANNEL : This is the channel on which the Slack notifications will be posted
+  # Some template for the Slack message
+  if [ ${CIRCLE_BRANCH} == "master" ]; then
+    ENVIRONMENT="production"
+  else
+    ENVIRONMENT="staging"
+  fi
+  if [ "$1" == "success" ]; then
+      MESSAGE_TEXT="The ${CIRCLE_BRANCH} branch has been deployed to the ${ENVIRONMENT} environment"
+      MESSAGE_COLOR="good"
+
+  fi
+  if [ "$1" == "fail" ]; then
+      MESSAGE_TEXT="Deployment to ${ENVIRONMENT} failed!!!"
+      MESSAGE_COLOR="danger"
+  fi
+
+  COMMIT_LINK="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}"
+  IMG_TAG="$(git rev-parse --short HEAD)"
+  CIRCLE_WORKFLOW_URL="https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+  SLACK_TEXT_TITLE="CircleCI Build #$CIRCLE_BUILD_NUM"
+  SLACK_DEPLOYMENT_TEXT="Executed Git Commit <$COMMIT_LINK|${IMG_TAG}>: ${MESSAGE_TEXT}"
+}
+
+send_notification() {
+
+  # Sending the Slack notification
+
+  curl -X POST --data-urlencode \
+  "payload={
+      \"channel\": \"${DEPLOYMENT_CHANNEL}\",
+      \"username\": \"JobNotification\",
+      \"attachments\": [{
+          \"fallback\": \"CircleCI job notification\",
+          \"color\": \"${MESSAGE_COLOR}\",
+          \"author_name\": \"Branch: $CIRCLE_BRANCH by ${CIRCLE_USERNAME}\",
+          \"author_link\": \"https://github.com/AndelaOSP/andela-societies-backend/tree/${CIRCLE_BRANCH}\",
+          \"title\": \"${SLACK_TEXT_TITLE}\",
+          \"title_link\": \"$CIRCLE_WORKFLOW_URL\",
+          \"text\": \"${SLACK_DEPLOYMENT_TEXT}\"
+      }]
+  }" \
+  "${SLACK_CHANNEL_HOOK}"
+}
+
+main() {
+  echo "Declaring environment variables"
+  declare_env_variables "$@"
+
+  echo "Sending notification"
+  send_notification
+}
+
+main "$@"


### PR DESCRIPTION
##### What does this PR do?

This Pull Request introduces notifications that will be specifically triggered when a deployment is made on Github by a push on either the master or develop branch.

##### Description of Task to be completed?
The task involves notifying the developers in the team and the TTL once a successful deployment has been made to production or staging or if a failure occurred during deployment. 

##### Any background context you want to provide?
None

##### What are the relevant Pivotal Tracker stories?
https://www.pivotaltracker.com/story/show/161539722

##### Questions?
None
##### Screenshots?
A sample of the messages that will be sent to the slack channel after a production deployment, both success and failure.
![image](https://user-images.githubusercontent.com/29925144/48050578-58340580-e1b3-11e8-8147-b1ae8f2850b8.png)
A sample of the messages that will be sent to the slack channel after a staging deployment, both success and failure. Ignore the branch name in this screenshot.
![image](https://user-images.githubusercontent.com/29925144/48050586-5d915000-e1b3-11e8-86bd-8b6a03ddc85b.png)



